### PR TITLE
Feature: metrics input with JSON output and label mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,14 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
             os: ubuntu-24.04
             compiler: "gcc"
-            cargo_args: "--no-default-features --features shell,ros2"
+            cargo_args: "--no-default-features --features shell,ros2,metrics"
             ros_distro: "jazzy"
             ros_setup_script: "/opt/ros/jazzy/setup.bash"
           - artifact_prefix: "bridge-ros2-humble"
             target: "x86_64-unknown-linux-gnu"
             os: ubuntu-22.04
             compiler: "gcc"
-            cargo_args: "--no-default-features --features shell,ros2"
+            cargo_args: "--no-default-features --features shell,ros2,metrics"
             ros_distro: "humble"
             ros_setup_script: "/opt/ros/humble/setup.bash"
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -385,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,7 +431,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1162,7 +1168,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1461,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1531,6 +1537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,12 +1575,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
+name = "nom"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "winapi",
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1596,29 +1609,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
 
 [[package]]
 name = "object"
@@ -1958,7 +1952,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "sysinfo",
+ "systemstat",
  "tokio",
  "toml",
 ]
@@ -2590,17 +2584,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.37.2"
+name = "systemstat"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "a6e89b75de097d0c52a1dc2114e19439d55f0e2e42d32168c6df44f139dfb66f"
 dependencies = [
+ "bytesize",
+ "lazy_static",
  "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
+ "nom",
+ "time",
+ "winapi",
 ]
 
 [[package]]
@@ -3193,41 +3187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,20 +3194,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3275,34 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-result"
@@ -3310,16 +3233,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -3328,7 +3242,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3355,7 +3269,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3387,15 +3301,6 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -728,7 +728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1162,7 +1162,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1461,7 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1563,6 +1563,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,10 +1596,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -1930,6 +1958,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sysinfo",
  "tokio",
  "toml",
 ]
@@ -2233,7 +2262,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2291,7 +2320,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2558,6 +2587,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -3140,7 +3183,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3150,6 +3193,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,9 +3235,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3186,9 +3275,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -3196,7 +3310,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3205,7 +3328,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3232,7 +3355,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3264,6 +3387,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,27 +6,34 @@ edition = "2024"
 
 [features]
 default = ["shell"]
-all-inputs = ["shell", "ros1", "ros2"]
+all-inputs = ["shell", "ros1", "ros2", "metrics"]
 ros1 = ["dep:rosrust"]
 ros2 = ["dep:rclrs", "dep:ros2_message"]
 shell = []
+metrics = []
 ci = []
 
 
 [dependencies]
-tokio = { version = "1.49.0", features = ["macros", "rt", "signal", "sync", "time"] }
+tokio = { version = "1.49.0", features = [
+  "macros",
+  "rt",
+  "signal",
+  "sync",
+  "time",
+] }
 async-trait = "0.1.89"
 toml = "1.0.3"
 serde = { version = "1.0.228", features = ["derive"] }
 bytes = "1.11.1"
-reduct-rs = { git="https://github.com/reductstore/reduct-rs.git", version = "1.19.0" }
+reduct-rs = { git = "https://github.com/reductstore/reduct-rs.git", version = "1.19.0" }
 anyhow = "1.0.102"
 log = "0.4.28"
 env_logger = "0.11.8"
 regex = "1.12.2"
 serde_json = "1.0.145"
 rosrust = { version = "0.9.13", optional = true, git = "https://github.com/reductstore/rosrust.git", tag = "v0.9.13" }
-rclrs = { git = "https://github.com/reductstore/ros2_rust", optional = true , version = "0.7.0"}
+rclrs = { git = "https://github.com/reductstore/ros2_rust", optional = true, version = "0.7.0" }
 ros2_message = { git = "https://github.com/reductstore/ros2_message", optional = true, version = "0.1.1" }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ all-inputs = ["shell", "ros1", "ros2", "metrics"]
 ros1 = ["dep:rosrust"]
 ros2 = ["dep:rclrs", "dep:ros2_message"]
 shell = []
-metrics = ["dep:sysinfo"]
+metrics = ["dep:systemstat"]
 ci = []
 
 
@@ -32,11 +32,10 @@ log = "0.4.28"
 env_logger = "0.11.8"
 regex = "1.12.2"
 serde_json = "1.0.145"
-sysinfo = { version = "0.37.2", optional = true }
 rosrust = { version = "0.9.13", optional = true, git = "https://github.com/reductstore/rosrust.git", tag = "v0.9.13" }
 rclrs = { git = "https://github.com/reductstore/ros2_rust", optional = true, version = "0.7.0" }
 ros2_message = { git = "https://github.com/reductstore/ros2_message", optional = true, version = "0.1.1" }
-
+systemstat = { version = "0.2.6", optional = true }
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ all-inputs = ["shell", "ros1", "ros2", "metrics"]
 ros1 = ["dep:rosrust"]
 ros2 = ["dep:rclrs", "dep:ros2_message"]
 shell = []
-metrics = []
+metrics = ["dep:sysinfo"]
 ci = []
 
 
@@ -32,6 +32,7 @@ log = "0.4.28"
 env_logger = "0.11.8"
 regex = "1.12.2"
 serde_json = "1.0.145"
+sysinfo = { version = "0.37.2", optional = true }
 rosrust = { version = "0.9.13", optional = true, git = "https://github.com/reductstore/rosrust.git", tag = "v0.9.13" }
 rclrs = { git = "https://github.com/reductstore/ros2_rust", optional = true, version = "0.7.0" }
 ros2_message = { git = "https://github.com/reductstore/ros2_message", optional = true, version = "0.1.1" }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An `input` is a data source. It reads data from a system and produces records fo
 
 Supported input types include:
 
+- [Metrics](src/input/metrics/README.md) - collect host CPU, memory, and disk metrics as JSON records.
 - [Shell](src/input/shell/README.md) - run shell commands on a fixed interval and store output lines as records.
 - [ROS1](src/input/ros1/README.md) - subscribe to ROS1 topics and store ROS messages as records.
 - [ROS2](src/input/ros2/README.md) - subscribe to ROS2 topics and store serialized CDR payloads as records.
@@ -84,6 +85,7 @@ cargo install reduct-bridge
 ```
 
 `cargo install reduct-bridge` builds the default feature set, which includes only the `shell` input.
+For metrics-specific build and runtime guidance, see [Metrics input documentation](src/input/metrics/README.md).
 For ROS2-specific build and runtime guidance, see [ROS2 input documentation](src/input/ros2/README.md).
 
 To build additional inputs explicitly from source:

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -11,10 +11,18 @@ bucket = "my-bucket"
 # Required key prefix inside the bucket.
 prefix = ""
 
-
-# List of subscribed topics for this input.
+# Metrics input configuration.
+# Structure: [inputs.metrics.<input_name>]
 [inputs.metrics.metrics_all]
+# Repeat metric collection every N seconds.
 repeat_interval = 1
+# Optional: records are written as metrics-cpu, metrics-memory, metrics-disk by default.
+# entry_prefix = "metrics"
+# Optional: collect all supported metrics if omitted.
+# metrics = ["cpu", "memory", "disk"]
+# Optional disk filters:
+# mount_points = ["/"]
+# ignore_fs = ["tmpfs", "devtmpfs", "proc", "sysfs", "squashfs"]
 labels = [
     { field = "user_percent", label = "user_percent" },
 ]
@@ -25,5 +33,5 @@ remote = "local"
 inputs = ["metrics_all"]
 # Optional pipeline-level label routing rules.
 labels = [
-    { from = "/metrics/cpu", labels = ["user_percent"], to = "*" }
+    { from = "metrics-cpu", labels = ["user_percent"], to = "*" }
 ]

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -1,0 +1,29 @@
+# ReductStore remote destination.
+[[remotes.reduct]]
+# Unique remote name referenced by pipelines.<name>.remote.
+name = "local"
+# ReductStore base URL.
+url = "http://localhost:8383"
+# API token used for authentication.
+token_api = "***"
+# Target bucket for all records from this remote.
+bucket = "my-bucket"
+# Required key prefix inside the bucket.
+prefix = ""
+
+
+# List of subscribed topics for this input.
+[inputs.metrics.metrics_all]
+repeat_interval = 1
+labels = [
+    { field = "user_percent", label = "user_percent" },
+]
+
+
+[pipelines.metrics_pipeline]
+remote = "local"
+inputs = ["metrics_all"]
+# Optional pipeline-level label routing rules.
+labels = [
+    { from = "/metrics/cpu", labels = ["user_percent"], to = "*" }
+]

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -16,7 +16,7 @@ prefix = ""
 [inputs.metrics.metrics_all]
 # Repeat metric collection every N seconds.
 repeat_interval = 1
-# Optional: records are written as metrics-cpu, metrics-memory, metrics-disk by default.
+# Optional: records are written as metrics/cpu, metrics/memory, metrics/disk by default.
 # entry_prefix = "metrics"
 # Optional: collect all supported metrics if omitted.
 # metrics = ["cpu", "memory", "disk"]
@@ -33,5 +33,5 @@ remote = "local"
 inputs = ["metrics_all"]
 # Optional pipeline-level label routing rules.
 labels = [
-    { from = "metrics-cpu", labels = ["user_percent"], to = "*" }
+    { from = "metrics/cpu", labels = ["user_percent"], to = "*" }
 ]

--- a/src/input.rs
+++ b/src/input.rs
@@ -80,7 +80,7 @@ impl InputBuilder {
                 let input_cfg: metrics::MetricsConfig = parse_entry(input_table)?;
                 debug!("Creating metrics launcher for input '{}'", input_name);
                 let launcher = metrics::MetricsInstance::new(input_cfg);
-                launcher.launch(pipeline_ts).await
+                launcher.launch(pipeline_tx).await
             }
             _ => bail!(
                 "Unsupported input type '{}' for input '{}'",

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#[cfg(feature = "metrics")]
+mod metrics;
 #[cfg(feature = "ros1")]
 mod ros1;
 #[cfg(feature = "ros2")]
@@ -71,6 +74,13 @@ impl InputBuilder {
                 debug!("Creating shell launcher for input '{}'", input_name);
                 let launcher = shell::ShellInstance::new(input_cfg);
                 launcher.launch(pipeline_tx).await
+            }
+            #[cfg(feature = "metrics")]
+            "metrics" => {
+                let input_cfg: metrics::MetricsConfig = parse_entry(input_table)?;
+                debug!("Creating metrics launcher for input '{}'", input_name);
+                let launcher = metrics::MetricsInstance::new(input_cfg);
+                launcher.launch(pipeline_ts).await
             }
             _ => bail!(
                 "Unsupported input type '{}' for input '{}'",

--- a/src/input/metrics/README.md
+++ b/src/input/metrics/README.md
@@ -19,9 +19,9 @@ metrics = ["cpu", "memory", "disk"]
 
 # Optional: entry prefix for produced records (default = "metrics").
 # Records are written to:
-#   <entry_prefix>-cpu
-#   <entry_prefix>-memory
-#   <entry_prefix>-disk
+#   <entry_prefix>/cpu
+#   <entry_prefix>/memory
+#   <entry_prefix>/disk
 entry_prefix = "metrics"
 
 # Optional: only include these mount points in disk metrics (default = []).
@@ -104,7 +104,7 @@ cargo build --no-default-features --features all-inputs
 
 - If `metrics` is empty or omitted, the input collects all supported metrics.
 - Records are written as JSON with content type `application/json`.
-- Entry names use ReductStore-compatible formatting such as `metrics-cpu`.
+- Entry names use hierarchical paths such as `metrics/cpu`.
 - CPU aggregation uses `systemstat::cpu_load_aggregate()` and waits about one second before calling `.done()`.
 - Disk filtering uses `ignore_fs` and optional `mount_points`.
 - Empty `mount_points` means all mounts are considered before filesystem-type filtering.

--- a/src/input/metrics/README.md
+++ b/src/input/metrics/README.md
@@ -1,0 +1,115 @@
+# Metrics Input
+
+Use this input to collect host metrics and write them to ReductStore through a pipeline.
+
+## Documented TOML Example
+
+```toml
+# Input definition path:
+# [inputs.metrics.<input_name>]
+[inputs.metrics.metrics_all]
+
+# Required: run interval in seconds.
+# Must be > 0.
+repeat_interval = 5
+
+# Optional: selected metrics (default = all supported metrics).
+# Supported values: "cpu", "memory", "disk"
+metrics = ["cpu", "memory", "disk"]
+
+# Optional: entry prefix for produced records (default = "metrics").
+# Records are written to:
+#   <entry_prefix>-cpu
+#   <entry_prefix>-memory
+#   <entry_prefix>-disk
+entry_prefix = "metrics"
+
+# Optional: only include these mount points in disk metrics (default = []).
+# If empty, all mounts are considered before ignore_fs filtering.
+mount_points = ["/", "/data"]
+
+# Optional: ignore these filesystem types in disk metrics.
+# If omitted, a default ignore list is used.
+ignore_fs = ["tmpfs", "devtmpfs", "proc", "sysfs", "squashfs"]
+
+# Optional label rules (default = []):
+# 1) Dynamic field label:
+#    { field = "path.to.value", label = "label_name" }
+#    - path uses dot notation; numeric segments are array indexes.
+# 2) Static labels:
+#    { static = { source = "metrics", site = "lab" } }
+# Merge behavior:
+# - static labels applied first
+# - field labels applied after static and can override same keys
+labels = [
+  { field = "user_percent", label = "cpu_user" },
+  { static = { source = "metrics" } }
+]
+```
+
+## Sample JSON Payloads
+
+CPU payload:
+
+```json
+{
+  "timestamp_us": 1776066575130248,
+  "user_percent": 4.1,
+  "system_percent": 1.7,
+  "idle_percent": 94.2
+}
+```
+
+Memory payload:
+
+```json
+{
+  "timestamp_us": 1776066575130248,
+  "total_bytes": 16724869120,
+  "free_bytes": 7317061632
+}
+```
+
+Disk payload:
+
+```json
+{
+  "timestamp_us": 1776066575130248,
+  "disks": [
+    {
+      "fs_mounted_on": "/",
+      "fs_type": "ext4",
+      "total_bytes": 502392610816,
+      "available_bytes": 37836242944
+    }
+  ]
+}
+```
+
+## Build
+
+Build only metrics input support:
+
+```bash
+cargo build --no-default-features --features metrics
+```
+
+Build all inputs in one command:
+
+```bash
+cargo build --no-default-features --features all-inputs
+```
+
+## Runtime Notes
+
+- If `metrics` is empty or omitted, the input collects all supported metrics.
+- Records are written as JSON with content type `application/json`.
+- Entry names use ReductStore-compatible formatting such as `metrics-cpu`.
+- CPU aggregation uses `systemstat::cpu_load_aggregate()` and waits about one second before calling `.done()`.
+- Disk filtering uses `ignore_fs` and optional `mount_points`.
+- Empty `mount_points` means all mounts are considered before filesystem-type filtering.
+
+## Changes
+
+- `v0.1.0`: Metrics input introduced.
+- `v0.1.0`: Configurable disk filtering via `mount_points` and `ignore_fs`.

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -65,6 +65,25 @@ fn default_entry_prefix() -> String {
     "/metrics".to_string()
 }
 
+fn build_metric_payload(kind: &MetricKind, timestamp_us: u64) -> serde_json::Value {
+    match kind {
+        MetricKind::Cpu => json!({
+            "timestamp_us": timestamp_us,
+            "usage_percent": 42.5
+        }),
+        MetricKind::Memory => json!({
+            "timestamp_us": timestamp_us,
+            "used_bytes": 8_000_000_000u64,
+            "total_bytes": 16_000_000_000u64,
+        }),
+        MetricKind::Disk => json!({
+            "timestamp_us": timestamp_us,
+            "total_bytes": 512_000_000_000u64,
+            "available_bytes": 256_000_000_000u64,
+        }),
+    }
+}
+
 #[async_trait]
 impl InputLauncher for MetricsInstance {
     async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
@@ -118,6 +137,7 @@ impl InputLauncher for MetricsInstance {
                             cfg.entry_prefix,
                             selected_metrics
                         );
+
                     }
                 }
             }

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -70,7 +70,7 @@ impl MetricsInstance {
 }
 
 fn default_entry_prefix() -> String {
-    "/metrics".to_string()
+    "metrics".to_string()
 }
 
 fn default_ignore_fs() -> Vec<String> {
@@ -101,9 +101,21 @@ fn default_ignore_fs() -> Vec<String> {
 }
 
 fn build_cpu_payload(system: &System, timestamp_us: u64) -> Option<serde_json::Value> {
-    let cpu = system.cpu_load_aggregate().ok()?;
+    let cpu = match system.cpu_load_aggregate() {
+        Ok(cpu) => cpu,
+        Err(err) => {
+            warn!("Failed to start CPU aggregate measurement: {}", err);
+            return None;
+        }
+    };
     std::thread::sleep(std::time::Duration::from_secs(1));
-    let done = cpu.done().ok()?;
+    let done = match cpu.done() {
+        Ok(done) => done,
+        Err(err) => {
+            warn!("Failed to finish CPU aggregate measurement: {}", err);
+            return None;
+        }
+    };
 
     Some(json!({
         "timestamp_us": timestamp_us,
@@ -243,11 +255,7 @@ fn build_record(
 
     Ok(Record {
         timestamp_us,
-        entry_name: format!(
-            "{}/{}",
-            cfg.entry_prefix.trim_end_matches('/'),
-            metric_name(kind)
-        ),
+        entry_name: format!("{}-{}", cfg.entry_prefix.trim_matches('/'), metric_name(kind)),
         content: content.into(),
         content_type: Some("application/json".to_string()),
         labels,
@@ -355,7 +363,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(cfg.repeat_interval, 5);
-        assert_eq!(cfg.entry_prefix, "/metrics");
+        assert_eq!(cfg.entry_prefix, "metrics");
         assert!(cfg.metrics.is_empty());
         assert!(cfg.mount_points.is_empty());
         assert!(!cfg.ignore_fs.is_empty());
@@ -439,7 +447,7 @@ mod tests {
         let record = build_record(&cfg, &MetricKind::Cpu, &payload, 42).unwrap();
 
         assert_eq!(record.timestamp_us, 42);
-        assert_eq!(record.entry_name, "/metrics/cpu");
+        assert_eq!(record.entry_name, "metrics-cpu");
         assert_eq!(record.content_type, Some("application/json".to_string()));
         assert_eq!(record.labels.get("source"), Some(&"metrics".to_string()));
     }
@@ -511,7 +519,7 @@ mod tests {
 
         match message {
             Message::Data(record) => {
-                assert_eq!(record.entry_name, "/metrics/memory");
+                assert_eq!(record.entry_name, "metrics-memory");
                 assert_eq!(record.content_type, Some("application/json".to_string()));
             }
             other => panic!("expected data message, got {other:?}"),
@@ -535,7 +543,7 @@ mod tests {
 
         assert_eq!(cfg.repeat_interval, 1);
         assert!(cfg.metrics.is_empty());
-        assert_eq!(cfg.entry_prefix, "/metrics");
+        assert_eq!(cfg.entry_prefix, "metrics");
         assert_eq!(cfg.labels.len(), 1);
     }
 }

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -255,7 +255,11 @@ fn build_record(
 
     Ok(Record {
         timestamp_us,
-        entry_name: format!("{}-{}", cfg.entry_prefix.trim_matches('/'), metric_name(kind)),
+        entry_name: format!(
+            "{}-{}",
+            cfg.entry_prefix.trim_matches('/'),
+            metric_name(kind)
+        ),
         content: content.into(),
         content_type: Some("application/json".to_string()),
         labels,

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -36,6 +36,10 @@ pub struct MetricsConfig {
     #[serde(default = "default_entry_prefix")]
     pub entry_prefix: String,
     #[serde(default)]
+    pub mount_points: Vec<String>,
+    #[serde(default = "default_ignore_fs")]
+    pub ignore_fs: Vec<String>,
+    #[serde(default)]
     pub labels: Vec<MetricsLabelRule>,
 }
 
@@ -46,7 +50,7 @@ pub enum MetricsLabelRule {
     Field { field: String, label: String },
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum MetricKind {
     Cpu,
@@ -67,6 +71,33 @@ impl MetricsInstance {
 
 fn default_entry_prefix() -> String {
     "/metrics".to_string()
+}
+
+fn default_ignore_fs() -> Vec<String> {
+    vec![
+        "autofs".to_string(),
+        "tmpfs".to_string(),
+        "proc".to_string(),
+        "sysfs".to_string(),
+        "devpts".to_string(),
+        "devtmpfs".to_string(),
+        "devfs".to_string(),
+        "efivarfs".to_string(),
+        "securityfs".to_string(),
+        "cgroup2".to_string(),
+        "pstore".to_string(),
+        "bpf".to_string(),
+        "hugetlbfs".to_string(),
+        "mqueue".to_string(),
+        "debugfs".to_string(),
+        "tracefs".to_string(),
+        "configfs".to_string(),
+        "fusectl".to_string(),
+        "iso9660".to_string(),
+        "overlay".to_string(),
+        "aufs".to_string(),
+        "squashfs".to_string(),
+    ]
 }
 
 fn build_cpu_payload(system: &System, timestamp_us: u64) -> Option<serde_json::Value> {
@@ -93,11 +124,34 @@ fn build_memory_payload(system: &System, timestamp_us: u64) -> Option<serde_json
     }
 }
 
-fn build_disk_payload(system: &System, timestamp_us: u64) -> Option<serde_json::Value> {
+fn include_mount(cfg: &MetricsConfig, mounted_on: &str, fs_type: &str, total_bytes: u64) -> bool {
+    if total_bytes == 0 {
+        return false;
+    }
+
+    if cfg.ignore_fs.iter().any(|ignored| ignored == fs_type) {
+        return false;
+    }
+
+    if cfg.mount_points.is_empty() {
+        return true;
+    }
+
+    cfg.mount_points.iter().any(|mount| mount == mounted_on)
+}
+
+fn build_disk_payload(
+    cfg: &MetricsConfig,
+    system: &System,
+    timestamp_us: u64,
+) -> Option<serde_json::Value> {
     match system.mounts() {
         Ok(mounts) => {
             let items: Vec<_> = mounts
                 .into_iter()
+                .filter(|mount| {
+                    include_mount(cfg, &mount.fs_mounted_on, &mount.fs_type, mount.total.as_u64())
+                })
                 .map(|mount| {
                     json!({
                         "fs_mounted_on": mount.fs_mounted_on,
@@ -118,6 +172,7 @@ fn build_disk_payload(system: &System, timestamp_us: u64) -> Option<serde_json::
 }
 
 fn build_metric_payload(
+    cfg: &MetricsConfig,
     kind: &MetricKind,
     system: &System,
     timestamp_us: u64,
@@ -125,7 +180,7 @@ fn build_metric_payload(
     match kind {
         MetricKind::Cpu => build_cpu_payload(system, timestamp_us),
         MetricKind::Memory => build_memory_payload(system, timestamp_us),
-        MetricKind::Disk => build_disk_payload(system, timestamp_us),
+        MetricKind::Disk => build_disk_payload(cfg, system, timestamp_us),
     }
 }
 
@@ -134,6 +189,14 @@ fn current_timestamp_us() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_micros() as u64
+}
+
+fn selected_metrics(cfg: &MetricsConfig) -> Vec<MetricKind> {
+    if cfg.metrics.is_empty() {
+        vec![MetricKind::Cpu, MetricKind::Memory, MetricKind::Disk]
+    } else {
+        cfg.metrics.clone()
+    }
 }
 
 fn metric_name(kind: &MetricKind) -> &'static str {
@@ -195,11 +258,7 @@ impl InputLauncher for MetricsInstance {
             bail!("Metrics input repeat_interval must be greater than 0 seconds");
         }
 
-        let selected_metrics = if cfg.metrics.is_empty() {
-            vec![MetricKind::Cpu, MetricKind::Memory, MetricKind::Disk]
-        } else {
-            cfg.metrics.clone()
-        };
+        let selected_metrics = selected_metrics(&cfg);
 
         info!(
             "Launching metrics input every {}s with {} selected metric(s) and prefix '{}'",
@@ -243,7 +302,7 @@ impl InputLauncher for MetricsInstance {
                         for kind in &selected_metrics {
                             let timestamp_us = current_timestamp_us();
 
-                            let Some(payload) = build_metric_payload(kind, &system, timestamp_us) else {
+                            let Some(payload) = build_metric_payload(&cfg, kind, &system, timestamp_us) else {
                                 warn!("Failed to collect {:?} metrics, skipping this tick", kind);
                                 continue;
                             };
@@ -265,5 +324,213 @@ impl InputLauncher for MetricsInstance {
         });
 
         Ok(tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MetricKind, MetricsConfig, MetricsLabelRule, build_labels, build_record, include_mount,
+        selected_metrics, MetricsInstance,
+    };
+    use crate::input::InputLauncher;
+    use crate::message::Message;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use tokio::sync::mpsc::channel;
+    use tokio::time::{Duration, timeout};
+
+    #[test]
+    fn parses_defaults_for_metrics_config() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 5
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.repeat_interval, 5);
+        assert_eq!(cfg.entry_prefix, "/metrics");
+        assert!(cfg.metrics.is_empty());
+        assert!(cfg.mount_points.is_empty());
+        assert!(!cfg.ignore_fs.is_empty());
+        assert!(cfg.labels.is_empty());
+    }
+
+    #[test]
+    fn defaults_to_all_metrics_when_none_selected() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 5
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            selected_metrics(&cfg),
+            vec![MetricKind::Cpu, MetricKind::Memory, MetricKind::Disk]
+        );
+    }
+
+    #[test]
+    fn keeps_explicit_metric_selection() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 5
+            metrics = ["cpu", "disk"]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(selected_metrics(&cfg), vec![MetricKind::Cpu, MetricKind::Disk]);
+    }
+
+    #[test]
+    fn builds_static_and_field_labels() {
+        let payload = json!({
+            "user_percent": 12.5,
+            "nested": {
+                "name": "host-a"
+            }
+        });
+        let rules = vec![
+            MetricsLabelRule::Static {
+                r#static: HashMap::from([("source".to_string(), "metrics".to_string())]),
+            },
+            MetricsLabelRule::Field {
+                field: "user_percent".to_string(),
+                label: "cpu_user".to_string(),
+            },
+            MetricsLabelRule::Field {
+                field: "nested.name".to_string(),
+                label: "host".to_string(),
+            },
+        ];
+
+        let labels = build_labels(&rules, &payload);
+
+        assert_eq!(labels.get("source"), Some(&"metrics".to_string()));
+        assert_eq!(labels.get("cpu_user"), Some(&"12.5".to_string()));
+        assert_eq!(labels.get("host"), Some(&"host-a".to_string()));
+    }
+
+    #[test]
+    fn builds_record_with_default_entry_prefix_and_json_type() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 5
+            labels = [{ static = { source = "metrics" } }]
+            "#,
+        )
+        .unwrap();
+        let payload = json!({
+            "timestamp_us": 42,
+            "user_percent": 10.0
+        });
+
+        let record = build_record(&cfg, &MetricKind::Cpu, &payload, 42).unwrap();
+
+        assert_eq!(record.timestamp_us, 42);
+        assert_eq!(record.entry_name, "/metrics/cpu");
+        assert_eq!(record.content_type, Some("application/json".to_string()));
+        assert_eq!(record.labels.get("source"), Some(&"metrics".to_string()));
+    }
+
+    #[test]
+    fn ignores_filtered_filesystems_and_zero_sized_mounts() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 5
+            "#,
+        )
+        .unwrap();
+
+        assert!(!include_mount(&cfg, "/sys", "sysfs", 0));
+        assert!(!include_mount(&cfg, "/snap/core", "squashfs", 1024));
+        assert!(include_mount(&cfg, "/", "ext4", 1024));
+    }
+
+    #[test]
+    fn mount_points_override_keeps_only_selected_mounts() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 5
+            mount_points = ["/data"]
+            "#,
+        )
+        .unwrap();
+
+        assert!(include_mount(&cfg, "/data", "ext4", 1024));
+        assert!(!include_mount(&cfg, "/", "ext4", 1024));
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_repeat_interval() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 0
+            "#,
+        )
+        .unwrap();
+        let (pipeline_tx, _pipeline_rx) = channel::<Message>(8);
+
+        let err = MetricsInstance::new(cfg)
+            .launch(pipeline_tx)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("repeat_interval must be greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn launch_emits_metric_record_and_stops() {
+        let cfg: MetricsConfig = toml::from_str(
+            r#"
+            repeat_interval = 2
+            metrics = ["memory"]
+            "#,
+        )
+        .unwrap();
+        let (pipeline_tx, mut pipeline_rx) = channel::<Message>(8);
+
+        let control_tx = MetricsInstance::new(cfg).launch(pipeline_tx).await.unwrap();
+
+        let message = timeout(Duration::from_secs(4), pipeline_rx.recv())
+            .await
+            .expect("timed out waiting for metric message")
+            .expect("pipeline channel closed");
+
+        match message {
+            Message::Data(record) => {
+                assert_eq!(record.entry_name, "/metrics/memory");
+                assert_eq!(
+                    record.content_type,
+                    Some("application/json".to_string())
+                );
+            }
+            other => panic!("expected data message, got {other:?}"),
+        }
+
+        control_tx.send(Message::Stop).await.unwrap();
+    }
+
+    #[test]
+    fn example_metric_config_deserializes() {
+        let config_text = std::fs::read_to_string("examples/metric_config.toml").unwrap();
+        let config: toml::Value = toml::from_str(&config_text).unwrap();
+        let entry = config
+            .get("inputs")
+            .and_then(|v| v.get("metrics"))
+            .and_then(|v| v.get("metrics_all"))
+            .cloned()
+            .unwrap();
+
+        let cfg: MetricsConfig = entry.try_into().unwrap();
+
+        assert_eq!(cfg.repeat_interval, 1);
+        assert!(cfg.metrics.is_empty());
+        assert_eq!(cfg.entry_prefix, "/metrics");
+        assert_eq!(cfg.labels.len(), 1);
     }
 }

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -150,7 +150,12 @@ fn build_disk_payload(
             let items: Vec<_> = mounts
                 .into_iter()
                 .filter(|mount| {
-                    include_mount(cfg, &mount.fs_mounted_on, &mount.fs_type, mount.total.as_u64())
+                    include_mount(
+                        cfg,
+                        &mount.fs_mounted_on,
+                        &mount.fs_type,
+                        mount.total.as_u64(),
+                    )
                 })
                 .map(|mount| {
                     json!({
@@ -330,8 +335,8 @@ impl InputLauncher for MetricsInstance {
 #[cfg(test)]
 mod tests {
     use super::{
-        MetricKind, MetricsConfig, MetricsLabelRule, build_labels, build_record, include_mount,
-        selected_metrics, MetricsInstance,
+        MetricKind, MetricsConfig, MetricsInstance, MetricsLabelRule, build_labels, build_record,
+        include_mount, selected_metrics,
     };
     use crate::input::InputLauncher;
     use crate::message::Message;
@@ -382,7 +387,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(selected_metrics(&cfg), vec![MetricKind::Cpu, MetricKind::Disk]);
+        assert_eq!(
+            selected_metrics(&cfg),
+            vec![MetricKind::Cpu, MetricKind::Disk]
+        );
     }
 
     #[test]
@@ -504,10 +512,7 @@ mod tests {
         match message {
             Message::Data(record) => {
                 assert_eq!(record.entry_name, "/metrics/memory");
-                assert_eq!(
-                    record.content_type,
-                    Some("application/json".to_string())
-                );
+                assert_eq!(record.content_type, Some("application/json".to_string()));
             }
             other => panic!("expected data message, got {other:?}"),
         }

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 ReductSoftware UG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::input::InputLauncher;
+use crate::message::{Message, Record};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct MetricsConfig {
+    pub repeat_interval: u64,
+    pub metrics: Vec<MetricsEntry>,
+    pub entry_prefix: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<MetricsLabelRule>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum MetricsLabelRule {
+    Regex { regex: String, label: String },
+    Staic { labels: HashMap<String, String> },
+}

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -13,14 +13,24 @@
 // limitations under the License.
 
 use crate::input::InputLauncher;
-use crate::message::{Message, Record};
+use crate::message::Message;
+use anyhow::{Error, bail};
+use async_trait::async_trait;
+use log::{debug, info, warn};
 use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::sync::mpsc::{Sender, channel};
+use tokio::time::{Duration, interval};
+
+const CHANNEL_SIZE: usize = 1024;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct MetricsConfig {
     pub repeat_interval: u64,
-    pub metrics: Vec<MetricsEntry>,
-    pub entry_prefix: Option<String>,
+    #[serde(default)]
+    pub metrics: Vec<MetricKind>,
+    #[serde(default = "default_entry_prefix")]
+    pub entry_prefix: String,
     #[serde(default)]
     pub labels: Vec<MetricsLabelRule>,
 }
@@ -28,6 +38,91 @@ pub struct MetricsConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum MetricsLabelRule {
-    Regex { regex: String, label: String },
-    Staic { labels: HashMap<String, String> },
+    Static { r#static: HashMap<String, String> },
+    Field { field: String, label: String },
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum MetricKind {
+    Cpu,
+    Memory,
+    Disk,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct MetricsInstance {
+    pub cfg: MetricsConfig,
+}
+
+impl MetricsInstance {
+    pub fn new(cfg: MetricsConfig) -> Self {
+        Self { cfg }
+    }
+}
+
+fn default_entry_prefix() -> String {
+    "/metrics".to_string()
+}
+
+#[async_trait]
+impl InputLauncher for MetricsInstance {
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
+        let cfg = self.cfg.clone();
+
+        if cfg.repeat_interval == 0 {
+            bail!("Metrics input repeat_interval must be greater than 0 seconds");
+        }
+
+        let selected_metrics = if cfg.metrics.is_empty() {
+            vec![MetricKind::Cpu, MetricKind::Memory, MetricKind::Disk]
+        } else {
+            cfg.metrics.clone()
+        };
+
+        info!(
+            "Launching metrics input every {}s with {} selected metric(s) and prefix '{}'",
+            cfg.repeat_interval,
+            selected_metrics.len(),
+            cfg.entry_prefix
+        );
+
+        let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
+        tokio::spawn(async move {
+            debug!("Metrics worker task started");
+            let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
+
+            loop {
+                tokio::select! {
+                    maybe_msg = rx.recv() => {
+                        match maybe_msg {
+                            Some(Message::Stop) => {
+                                if let Err(err) = pipeline_tx.send(Message::Stop).await {
+                                    warn!("Failed to forward metrics stop message to pipeline: {}", err);
+                                }
+                                info!("Stop message received, shutting down metrics worker");
+                                break;
+                            }
+                            Some(other) => {
+                                debug!("Ignoring unsupported control message in metrics input: {:?}", other);
+                            }
+                            None => {
+                                info!("Metrics control channel closed, shutting down metrics worker");
+                                break;
+                            }
+                        }
+                    }
+                    _ = ticker.tick() => {
+                        debug!(
+                            "Metrics tick fired for prefix '{}' with metrics {:?}",
+                            cfg.entry_prefix,
+                            selected_metrics
+                        );
+                    }
+                }
+            }
+        });
+
+        Ok(tx)
+    }
 }

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -256,7 +256,7 @@ fn build_record(
     Ok(Record {
         timestamp_us,
         entry_name: format!(
-            "{}-{}",
+            "{}/{}",
             cfg.entry_prefix.trim_matches('/'),
             metric_name(kind)
         ),
@@ -451,7 +451,7 @@ mod tests {
         let record = build_record(&cfg, &MetricKind::Cpu, &payload, 42).unwrap();
 
         assert_eq!(record.timestamp_us, 42);
-        assert_eq!(record.entry_name, "metrics-cpu");
+        assert_eq!(record.entry_name, "metrics/cpu");
         assert_eq!(record.content_type, Some("application/json".to_string()));
         assert_eq!(record.labels.get("source"), Some(&"metrics".to_string()));
     }
@@ -523,7 +523,7 @@ mod tests {
 
         match message {
             Message::Data(record) => {
-                assert_eq!(record.entry_name, "metrics-memory");
+                assert_eq!(record.entry_name, "metrics/memory");
                 assert_eq!(record.content_type, Some("application/json".to_string()));
             }
             other => panic!("expected data message, got {other:?}"),

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -22,7 +22,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
-use sysinfo::{Disks, System};
+use systemstat::{Platform, System};
 use tokio::sync::mpsc::{Sender, channel};
 use tokio::time::{Duration, interval};
 
@@ -54,26 +54,6 @@ pub enum MetricKind {
     Disk,
 }
 
-#[derive(Debug)]
-struct MetricSources {
-    system: System,
-    disks: Disks,
-}
-
-impl MetricSources {
-    fn new() -> Self {
-        Self {
-            system: System::new_all(),
-            disks: Disks::new_with_refreshed_list(),
-        }
-    }
-
-    fn refresh(&mut self) {
-        self.system.refresh_cpu_all();
-        self.system.refresh_memory();
-        self.disks.refresh(true);
-    }
-}
 #[derive(Debug, Deserialize, Clone)]
 pub struct MetricsInstance {
     pub cfg: MetricsConfig,
@@ -89,49 +69,63 @@ fn default_entry_prefix() -> String {
     "/metrics".to_string()
 }
 
-fn build_cpu_payload(system: &System, timestamp_us: u64) -> serde_json::Value {
-    json!({
+fn build_cpu_payload(system: &System, timestamp_us: u64) -> Option<serde_json::Value> {
+    let cpu = system.cpu_load_aggregate().ok()?;
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    let done = cpu.done().ok()?;
+
+    Some(json!({
         "timestamp_us": timestamp_us,
-        "cpu_usage_percent": system.global_cpu_usage(),
-    })
+        "user_percent": done.user * 100.0,
+        "system_percent": done.system * 100.0,
+        "idle_percent": done.idle * 100.0,
+    }))
 }
 
-fn build_memory_payload(system: &System, timestamp_us: u64) -> serde_json::Value {
-    json!({
-        "timestamp_us": timestamp_us,
-        "memory_used_bytes": system.used_memory(),
-        "memory_total_bytes": system.total_memory(),
-    })
+fn build_memory_payload(system: &System, timestamp_us: u64) -> Option<serde_json::Value> {
+    match system.memory() {
+        Ok(mem) => Some(json!({
+            "timestamp_us": timestamp_us,
+            "total_bytes": mem.total.as_u64(),
+            "free_bytes": mem.free.as_u64(),
+        })),
+        Err(_) => None,
+    }
 }
 
-fn build_disk_payload(disks: &Disks, timestamp_us: u64) -> serde_json::Value {
-    let disk_info: Vec<_> = disks
-        .iter()
-        .map(|disk| {
-            json!({
-                "name": disk.name().to_string_lossy(),
-                "mount_point": disk.mount_point().to_string_lossy(),
-                "total_bytes": disk.total_space(),
-                "available_bytes": disk.available_space(),
-            })
-        })
-        .collect();
+fn build_disk_payload(system: &System, timestamp_us: u64) -> Option<serde_json::Value> {
+    match system.mounts() {
+        Ok(mounts) => {
+            let items: Vec<_> = mounts
+                .into_iter()
+                .map(|mount| {
+                    json!({
+                        "fs_mounted_on": mount.fs_mounted_on,
+                        "fs_type": mount.fs_type,
+                        "total_bytes": mount.total.as_u64(),
+                        "available_bytes": mount.avail.as_u64(),
+                    })
+                })
+                .collect();
 
-    json!({
-        "timestamp_us": timestamp_us,
-        "disks": disk_info,
-    })
+            Some(json!({
+                "timestamp_us": timestamp_us,
+                "disks": items,
+            }))
+        }
+        Err(_) => None,
+    }
 }
 
 fn build_metric_payload(
     kind: &MetricKind,
-    sources: &MetricSources,
+    system: &System,
     timestamp_us: u64,
-) -> serde_json::Value {
+) -> Option<serde_json::Value> {
     match kind {
-        MetricKind::Cpu => build_cpu_payload(&sources.system, timestamp_us),
-        MetricKind::Memory => build_memory_payload(&sources.system, timestamp_us),
-        MetricKind::Disk => build_disk_payload(&sources.disks, timestamp_us),
+        MetricKind::Cpu => build_cpu_payload(system, timestamp_us),
+        MetricKind::Memory => build_memory_payload(system, timestamp_us),
+        MetricKind::Disk => build_disk_payload(system, timestamp_us),
     }
 }
 
@@ -218,7 +212,7 @@ impl InputLauncher for MetricsInstance {
         tokio::spawn(async move {
             debug!("Metrics worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
-            let mut sources = MetricSources::new();
+            let system = System::new();
 
             loop {
                 tokio::select! {
@@ -246,10 +240,13 @@ impl InputLauncher for MetricsInstance {
                             cfg.entry_prefix,
                             selected_metrics
                         );
-                        sources.refresh();
                         for kind in &selected_metrics {
                             let timestamp_us = current_timestamp_us();
-                            let payload = build_metric_payload(kind, &sources, timestamp_us);
+
+                            let Some(payload) = build_metric_payload(kind, &system, timestamp_us) else {
+                                warn!("Failed to collect {:?} metrics, skipping this tick", kind);
+                                continue;
+                            };
 
                             match build_record(&cfg, kind, &payload, timestamp_us) {
                                 Ok(record) => {

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::formats::json::{extract_json_path, value_to_label};
 use crate::input::InputLauncher;
-use crate::message::Message;
+use crate::message::{Message, Record};
 use anyhow::{Error, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
 use serde::Deserialize;
+use serde_json::json;
 use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use sysinfo::{Disks, System};
 use tokio::sync::mpsc::{Sender, channel};
 use tokio::time::{Duration, interval};
 
@@ -50,6 +54,26 @@ pub enum MetricKind {
     Disk,
 }
 
+#[derive(Debug)]
+struct MetricSources {
+    system: System,
+    disks: Disks,
+}
+
+impl MetricSources {
+    fn new() -> Self {
+        Self {
+            system: System::new_all(),
+            disks: Disks::new_with_refreshed_list(),
+        }
+    }
+
+    fn refresh(&mut self) {
+        self.system.refresh_cpu_all();
+        self.system.refresh_memory();
+        self.disks.refresh(true);
+    }
+}
 #[derive(Debug, Deserialize, Clone)]
 pub struct MetricsInstance {
     pub cfg: MetricsConfig,
@@ -65,23 +89,107 @@ fn default_entry_prefix() -> String {
     "/metrics".to_string()
 }
 
-fn build_metric_payload(kind: &MetricKind, timestamp_us: u64) -> serde_json::Value {
+fn build_cpu_payload(system: &System, timestamp_us: u64) -> serde_json::Value {
+    json!({
+        "timestamp_us": timestamp_us,
+        "cpu_usage_percent": system.global_cpu_usage(),
+    })
+}
+
+fn build_memory_payload(system: &System, timestamp_us: u64) -> serde_json::Value {
+    json!({
+        "timestamp_us": timestamp_us,
+        "memory_used_bytes": system.used_memory(),
+        "memory_total_bytes": system.total_memory(),
+    })
+}
+
+fn build_disk_payload(disks: &Disks, timestamp_us: u64) -> serde_json::Value {
+    let disk_info: Vec<_> = disks
+        .iter()
+        .map(|disk| {
+            json!({
+                "name": disk.name().to_string_lossy(),
+                "mount_point": disk.mount_point().to_string_lossy(),
+                "total_bytes": disk.total_space(),
+                "available_bytes": disk.available_space(),
+            })
+        })
+        .collect();
+
+    json!({
+        "timestamp_us": timestamp_us,
+        "disks": disk_info,
+    })
+}
+
+fn build_metric_payload(
+    kind: &MetricKind,
+    sources: &MetricSources,
+    timestamp_us: u64,
+) -> serde_json::Value {
     match kind {
-        MetricKind::Cpu => json!({
-            "timestamp_us": timestamp_us,
-            "usage_percent": 42.5
-        }),
-        MetricKind::Memory => json!({
-            "timestamp_us": timestamp_us,
-            "used_bytes": 8_000_000_000u64,
-            "total_bytes": 16_000_000_000u64,
-        }),
-        MetricKind::Disk => json!({
-            "timestamp_us": timestamp_us,
-            "total_bytes": 512_000_000_000u64,
-            "available_bytes": 256_000_000_000u64,
-        }),
+        MetricKind::Cpu => build_cpu_payload(&sources.system, timestamp_us),
+        MetricKind::Memory => build_memory_payload(&sources.system, timestamp_us),
+        MetricKind::Disk => build_disk_payload(&sources.disks, timestamp_us),
     }
+}
+
+fn current_timestamp_us() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
+}
+
+fn metric_name(kind: &MetricKind) -> &'static str {
+    match kind {
+        MetricKind::Cpu => "cpu",
+        MetricKind::Memory => "memory",
+        MetricKind::Disk => "disk",
+    }
+}
+
+fn build_labels(
+    rules: &[MetricsLabelRule],
+    payload: &serde_json::Value,
+) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+    for rule in rules {
+        match rule {
+            MetricsLabelRule::Static { r#static } => {
+                labels.extend(r#static.clone());
+            }
+            MetricsLabelRule::Field { field, label } => {
+                if let Some(value) = extract_json_path(payload, field) {
+                    labels.insert(label.clone(), value_to_label(value));
+                }
+            }
+        }
+    }
+    labels
+}
+
+fn build_record(
+    cfg: &MetricsConfig,
+    kind: &MetricKind,
+    payload: &serde_json::Value,
+    timestamp_us: u64,
+) -> Result<Record, Error> {
+    let labels = build_labels(&cfg.labels, payload);
+    let content = serde_json::to_vec(payload)?;
+
+    Ok(Record {
+        timestamp_us,
+        entry_name: format!(
+            "{}/{}",
+            cfg.entry_prefix.trim_end_matches('/'),
+            metric_name(kind)
+        ),
+        content: content.into(),
+        content_type: Some("application/json".to_string()),
+        labels,
+    })
 }
 
 #[async_trait]
@@ -110,6 +218,7 @@ impl InputLauncher for MetricsInstance {
         tokio::spawn(async move {
             debug!("Metrics worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
+            let mut sources = MetricSources::new();
 
             loop {
                 tokio::select! {
@@ -137,7 +246,22 @@ impl InputLauncher for MetricsInstance {
                             cfg.entry_prefix,
                             selected_metrics
                         );
+                        sources.refresh();
+                        for kind in &selected_metrics {
+                            let timestamp_us = current_timestamp_us();
+                            let payload = build_metric_payload(kind, &sources, timestamp_us);
 
+                            match build_record(&cfg, kind, &payload, timestamp_us) {
+                                Ok(record) => {
+                                    if let Err(err) = pipeline_tx.send(Message::Data(record)).await {
+                                        warn!("Failed to forward metrics record to pipeline: {}", err);
+                                    }
+                                }
+                                Err(err) => {
+                                    warn!("Failed to build metrics record for {:?}: {}", kind, err);
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #14

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- added a new metrics input under [inputs.metrics.<name>]
- added support for collecting cpu, memory, and disk metrics
- emits JSON payloads to /metrics/<metric-name> by default, with configurable entry_prefix
- supports static and field-based labels using the same JSON path extraction helpers as other structured inputs
- implemented disk filtering with configurable mount_points and ignore_fs
- switched system metric collection to systemstat
- added metrics-focused unit/runtime tests covering config defaults, selection behavior, label extraction, record building, validation, runtime emission, and example-config parsing
- added an example config in examples/metric_config.toml

### Related issues

- #14

### Does this PR introduce a breaking change?

No.

### Other information:

- CPU aggregation uses systemstat::cpu_load_aggregate() and waits about one second before calling .done(), following the crate recommended usage.
- Documentation and changelog updates are still pending.
