### PR TITLE
Fix deterministic bridge shutdown by tracking component tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ permissions:
 env:
   REGISTRY_IMAGE: reduct/bridge
   AWS_LC_SYS_USE_PREBUILT: 0
-  ROS2_CACHE_VERSION: v1
 
 jobs:
   rust_fmt:
@@ -65,33 +64,14 @@ jobs:
             ros_setup_script: "/opt/ros/humble/setup.bash"
     steps:
       - uses: actions/checkout@v4
-      - name: Restore ROS2 cache
-        if: ${{ matrix.ros_setup_script != '' }}
-        id: ros2-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            /opt/ros/${{ matrix.ros_distro }}
-            /etc/apt/sources.list.d/ros2.list
-            /usr/share/keyrings/ros-archive-keyring.gpg
-          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
       - name: Install ROS2
-        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.ros_setup_script != '' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
-        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.ros_setup_script != '' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
-      - name: Save ROS2 cache
-        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            /opt/ros/${{ matrix.ros_distro }}
-            /etc/apt/sources.list.d/ros2.list
-            /usr/share/keyrings/ros-archive-keyring.gpg
-          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
       - uses: ./.github/actions/build-binaries
         with:
           minimal_rust_version: ${{ vars.MINIMAL_RUST_VERSION || 'stable' }}
@@ -133,23 +113,13 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@v4
-      - name: Restore ROS2 cache
-        if: ${{ matrix.ros_setup_script != '' }}
-        id: ros2-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            /opt/ros/${{ matrix.ros_distro }}
-            /etc/apt/sources.list.d/ros2.list
-            /usr/share/keyrings/ros-archive-keyring.gpg
-          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
       - name: Install ROS2
-        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.ros_setup_script != '' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
-        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.ros_setup_script != '' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
       - name: Download test artifact
         uses: actions/download-artifact@v4
@@ -227,22 +197,11 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
-      - name: Restore ROS2 cache
-        id: ros2-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            /opt/ros/${{ matrix.ros_distro }}
-            /etc/apt/sources.list.d/ros2.list
-            /usr/share/keyrings/ros-archive-keyring.gpg
-          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
       - name: Install ROS2
-        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
-        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
       - name: Download reduct-bridge Linux artifact
         uses: actions/download-artifact@v4
@@ -267,22 +226,11 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@v4
-      - name: Restore ROS2 cache
-        id: ros2-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            /opt/ros/jazzy
-            /etc/apt/sources.list.d/ros2.list
-            /usr/share/keyrings/ros-archive-keyring.gpg
-          key: ros2-${{ env.ROS2_CACHE_VERSION }}-ubuntu-24.04-jazzy
       - name: Install ROS2
-        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: jazzy
       - name: Install ROS2 interface packages
-        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y ros-jazzy-example-interfaces ros-jazzy-test-msgs
 
       - uses: ./.github/actions/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ permissions:
 env:
   REGISTRY_IMAGE: reduct/bridge
   AWS_LC_SYS_USE_PREBUILT: 0
+  ROS2_CACHE_VERSION: v1
 
 jobs:
   rust_fmt:
@@ -64,14 +65,33 @@ jobs:
             ros_setup_script: "/opt/ros/humble/setup.bash"
     steps:
       - uses: actions/checkout@v4
-      - name: Install ROS2
+      - name: Restore ROS2 cache
         if: ${{ matrix.ros_setup_script != '' }}
+        id: ros2-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /opt/ros/${{ matrix.ros_distro }}
+            /etc/apt/sources.list.d/ros2.list
+            /usr/share/keyrings/ros-archive-keyring.gpg
+          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
+      - name: Install ROS2
+        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
-        if: ${{ matrix.ros_setup_script != '' }}
+        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
+      - name: Save ROS2 cache
+        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /opt/ros/${{ matrix.ros_distro }}
+            /etc/apt/sources.list.d/ros2.list
+            /usr/share/keyrings/ros-archive-keyring.gpg
+          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
       - uses: ./.github/actions/build-binaries
         with:
           minimal_rust_version: ${{ vars.MINIMAL_RUST_VERSION || 'stable' }}
@@ -113,13 +133,23 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@v4
-      - name: Install ROS2
+      - name: Restore ROS2 cache
         if: ${{ matrix.ros_setup_script != '' }}
+        id: ros2-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /opt/ros/${{ matrix.ros_distro }}
+            /etc/apt/sources.list.d/ros2.list
+            /usr/share/keyrings/ros-archive-keyring.gpg
+          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
+      - name: Install ROS2
+        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
-        if: ${{ matrix.ros_setup_script != '' }}
+        if: ${{ matrix.ros_setup_script != '' && steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
       - name: Download test artifact
         uses: actions/download-artifact@v4
@@ -197,11 +227,22 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+      - name: Restore ROS2 cache
+        id: ros2-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /opt/ros/${{ matrix.ros_distro }}
+            /etc/apt/sources.list.d/ros2.list
+            /usr/share/keyrings/ros-archive-keyring.gpg
+          key: ros2-${{ env.ROS2_CACHE_VERSION }}-${{ matrix.os }}-${{ matrix.ros_distro }}
       - name: Install ROS2
+        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
+        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
       - name: Download reduct-bridge Linux artifact
         uses: actions/download-artifact@v4
@@ -226,11 +267,22 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@v4
+      - name: Restore ROS2 cache
+        id: ros2-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /opt/ros/jazzy
+            /etc/apt/sources.list.d/ros2.list
+            /usr/share/keyrings/ros-archive-keyring.gpg
+          key: ros2-${{ env.ROS2_CACHE_VERSION }}-ubuntu-24.04-jazzy
       - name: Install ROS2
+        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: jazzy
       - name: Install ROS2 interface packages
+        if: ${{ steps.ros2-cache-restore.outputs.cache-hit != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y ros-jazzy-example-interfaces ros-jazzy-test-msgs
 
       - uses: ./.github/actions/coverage

--- a/src/input.rs
+++ b/src/input.rs
@@ -23,6 +23,7 @@ mod shell;
 
 use crate::cfg::{find_keyed_entry, parse_entry};
 use crate::message::Message;
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, bail};
 use async_trait::async_trait;
 use log::debug;
@@ -31,7 +32,7 @@ use toml::Value;
 
 #[async_trait]
 pub trait InputLauncher: Send + Sync {
-    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error>;
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error>;
 }
 
 pub struct InputBuilder;
@@ -46,7 +47,7 @@ impl InputBuilder {
         config: &Value,
         input_name: &str,
         pipeline_tx: Sender<Message>,
-    ) -> Result<Sender<Message>, Error> {
+    ) -> Result<ComponentRuntime, Error> {
         let (input_type, input_table) = find_keyed_entry(config, "inputs", input_name)?;
         debug!(
             "Selected input '{}' from dynamic section type '{}'",

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -286,6 +286,7 @@ impl InputLauncher for MetricsInstance {
         );
 
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
+        let runtime_name = cfg.entry_prefix.clone();
         let task = tokio::spawn(async move {
             debug!("Metrics worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
@@ -338,7 +339,12 @@ impl InputLauncher for MetricsInstance {
             }
         });
 
-        Ok(ComponentRuntime { tx, task })
+        Ok(ComponentRuntime {
+            name: runtime_name,
+            kind: "input",
+            tx,
+            task,
+        })
     }
 }
 

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -286,7 +286,6 @@ impl InputLauncher for MetricsInstance {
         );
 
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
-        let runtime_name = cfg.entry_prefix.clone();
         let task = tokio::spawn(async move {
             debug!("Metrics worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
@@ -339,12 +338,7 @@ impl InputLauncher for MetricsInstance {
             }
         });
 
-        Ok(ComponentRuntime {
-            name: runtime_name,
-            kind: "input",
-            tx,
-            task,
-        })
+        Ok(ComponentRuntime { tx, task })
     }
 }
 

--- a/src/input/metrics/mod.rs
+++ b/src/input/metrics/mod.rs
@@ -15,6 +15,7 @@
 use crate::formats::json::{extract_json_path, value_to_label};
 use crate::input::InputLauncher;
 use crate::message::{Message, Record};
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -268,7 +269,7 @@ fn build_record(
 
 #[async_trait]
 impl InputLauncher for MetricsInstance {
-    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
 
         if cfg.repeat_interval == 0 {
@@ -285,7 +286,7 @@ impl InputLauncher for MetricsInstance {
         );
 
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             debug!("Metrics worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
             let system = System::new();
@@ -295,9 +296,6 @@ impl InputLauncher for MetricsInstance {
                     maybe_msg = rx.recv() => {
                         match maybe_msg {
                             Some(Message::Stop) => {
-                                if let Err(err) = pipeline_tx.send(Message::Stop).await {
-                                    warn!("Failed to forward metrics stop message to pipeline: {}", err);
-                                }
                                 info!("Stop message received, shutting down metrics worker");
                                 break;
                             }
@@ -340,7 +338,7 @@ impl InputLauncher for MetricsInstance {
             }
         });
 
-        Ok(tx)
+        Ok(ComponentRuntime { tx, task })
     }
 }
 
@@ -514,7 +512,7 @@ mod tests {
         .unwrap();
         let (pipeline_tx, mut pipeline_rx) = channel::<Message>(8);
 
-        let control_tx = MetricsInstance::new(cfg).launch(pipeline_tx).await.unwrap();
+        let runtime = MetricsInstance::new(cfg).launch(pipeline_tx).await.unwrap();
 
         let message = timeout(Duration::from_secs(4), pipeline_rx.recv())
             .await
@@ -529,7 +527,8 @@ mod tests {
             other => panic!("expected data message, got {other:?}"),
         }
 
-        control_tx.send(Message::Stop).await.unwrap();
+        runtime.tx.send(Message::Stop).await.unwrap();
+        runtime.task.await.unwrap();
     }
 
     #[test]

--- a/src/input/ros1/mod.rs
+++ b/src/input/ros1/mod.rs
@@ -42,7 +42,6 @@ impl InputLauncher for Ros1Instance {
         }
 
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
-        let runtime_name = cfg.node_name.clone();
 
         info!(
             "Launching ROS input '{}' with uri '{}'",
@@ -150,11 +149,6 @@ impl InputLauncher for Ros1Instance {
             }
         });
 
-        Ok(ComponentRuntime {
-            name: runtime_name,
-            kind: "input",
-            tx,
-            task,
-        })
+        Ok(ComponentRuntime { tx, task })
     }
 }

--- a/src/input/ros1/mod.rs
+++ b/src/input/ros1/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use crate::input::InputLauncher;
 use crate::message::Message;
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, anyhow, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -31,7 +32,7 @@ const CHANNEL_SIZE: usize = 1024;
 
 #[async_trait]
 impl InputLauncher for Ros1Instance {
-    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
         if cfg.queue_size == 0 {
             bail!("ROS input queue_size must be greater than 0");
@@ -121,7 +122,7 @@ impl InputLauncher for Ros1Instance {
         .await
         .map_err(|err| anyhow!("ROS startup worker task for '{}' failed: {}", cfg.node_name, err))??;
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             debug!("ROS worker task started for {}", cfg.node_name);
 
             loop {
@@ -129,9 +130,6 @@ impl InputLauncher for Ros1Instance {
                     Some(Message::Stop) => {
                         drop(subscribers);
                         debug!("ROS subscribers dropped");
-                        if let Err(err) = pipeline_tx.send(Message::Stop).await {
-                            warn!("Failed to forward ROS stop message to pipeline: {}", err);
-                        }
                         info!("Stop message received, shutting down ROS worker");
                         break;
                     }
@@ -151,6 +149,6 @@ impl InputLauncher for Ros1Instance {
             }
         });
 
-        Ok(tx)
+        Ok(ComponentRuntime { tx, task })
     }
 }

--- a/src/input/ros1/mod.rs
+++ b/src/input/ros1/mod.rs
@@ -42,6 +42,7 @@ impl InputLauncher for Ros1Instance {
         }
 
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
+        let runtime_name = cfg.node_name.clone();
 
         info!(
             "Launching ROS input '{}' with uri '{}'",
@@ -149,6 +150,11 @@ impl InputLauncher for Ros1Instance {
             }
         });
 
-        Ok(ComponentRuntime { tx, task })
+        Ok(ComponentRuntime {
+            name: runtime_name,
+            kind: "input",
+            tx,
+            task,
+        })
     }
 }

--- a/src/input/ros2/mod.rs
+++ b/src/input/ros2/mod.rs
@@ -21,7 +21,6 @@ impl InputLauncher for Ros2Instance {
     async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
         let control_node_name = cfg.node_name.clone();
-        let runtime_name = cfg.node_name.clone();
         if cfg.queue_size == 0 {
             bail!("ROS2 input queue_size must be greater than 0");
         }
@@ -82,11 +81,6 @@ impl InputLauncher for Ros2Instance {
             }
         });
 
-        Ok(ComponentRuntime {
-            name: runtime_name,
-            kind: "input",
-            tx,
-            task,
-        })
+        Ok(ComponentRuntime { tx, task })
     }
 }

--- a/src/input/ros2/mod.rs
+++ b/src/input/ros2/mod.rs
@@ -21,6 +21,7 @@ impl InputLauncher for Ros2Instance {
     async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
         let control_node_name = cfg.node_name.clone();
+        let runtime_name = cfg.node_name.clone();
         if cfg.queue_size == 0 {
             bail!("ROS2 input queue_size must be greater than 0");
         }
@@ -81,6 +82,11 @@ impl InputLauncher for Ros2Instance {
             }
         });
 
-        Ok(ComponentRuntime { tx, task })
+        Ok(ComponentRuntime {
+            name: runtime_name,
+            kind: "input",
+            tx,
+            task,
+        })
     }
 }

--- a/src/input/ros2/mod.rs
+++ b/src/input/ros2/mod.rs
@@ -1,5 +1,6 @@
 use crate::input::InputLauncher;
 use crate::message::Message;
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -17,7 +18,7 @@ const CHANNEL_SIZE: usize = 1024;
 
 #[async_trait]
 impl InputLauncher for Ros2Instance {
-    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
         let control_node_name = cfg.node_name.clone();
         if cfg.queue_size == 0 {
@@ -51,7 +52,7 @@ impl InputLauncher for Ros2Instance {
             Err(err) => bail!("ROS2 worker failed during startup: {}", err),
         }
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             debug!("ROS2 control task started for {}", control_node_name);
 
             loop {
@@ -60,9 +61,6 @@ impl InputLauncher for Ros2Instance {
                         stop.store(true, Ordering::Relaxed);
                         if let Err(err) = tokio::task::spawn_blocking(move || worker.join()).await {
                             warn!("Failed to join ROS2 worker thread: {}", err);
-                        }
-                        if let Err(err) = pipeline_tx.send(Message::Stop).await {
-                            warn!("Failed to forward ROS2 stop message to pipeline: {}", err);
                         }
                         info!("Stop message received, shutting down ROS2 worker");
                         break;
@@ -83,6 +81,6 @@ impl InputLauncher for Ros2Instance {
             }
         });
 
-        Ok(tx)
+        Ok(ComponentRuntime { tx, task })
     }
 }

--- a/src/input/shell/mod.rs
+++ b/src/input/shell/mod.rs
@@ -163,6 +163,7 @@ impl InputLauncher for ShellInstance {
             cfg.repeat_interval, cfg.entry_name, cfg.command
         );
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
+        let runtime_name = cfg.entry_name.clone();
         let task = tokio::spawn(async move {
             debug!("Shell worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
@@ -231,7 +232,12 @@ impl InputLauncher for ShellInstance {
             }
         });
 
-        Ok(ComponentRuntime { tx, task })
+        Ok(ComponentRuntime {
+            name: runtime_name,
+            kind: "input",
+            tx,
+            task,
+        })
     }
 }
 

--- a/src/input/shell/mod.rs
+++ b/src/input/shell/mod.rs
@@ -163,7 +163,6 @@ impl InputLauncher for ShellInstance {
             cfg.repeat_interval, cfg.entry_name, cfg.command
         );
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
-        let runtime_name = cfg.entry_name.clone();
         let task = tokio::spawn(async move {
             debug!("Shell worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
@@ -232,12 +231,7 @@ impl InputLauncher for ShellInstance {
             }
         });
 
-        Ok(ComponentRuntime {
-            name: runtime_name,
-            kind: "input",
-            tx,
-            task,
-        })
+        Ok(ComponentRuntime { tx, task })
     }
 }
 

--- a/src/input/shell/mod.rs
+++ b/src/input/shell/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use crate::input::InputLauncher;
 use crate::message::{Message, Record};
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -147,7 +148,7 @@ impl ShellInstance {
 
 #[async_trait]
 impl InputLauncher for ShellInstance {
-    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
         if cfg.repeat_interval == 0 {
             bail!("Shell input repeat_interval must be greater than 0 seconds");
@@ -162,7 +163,7 @@ impl InputLauncher for ShellInstance {
             cfg.repeat_interval, cfg.entry_name, cfg.command
         );
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             debug!("Shell worker task started");
             let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
 
@@ -171,9 +172,6 @@ impl InputLauncher for ShellInstance {
                     maybe_message = rx.recv() => {
                         match maybe_message {
                             Some(Message::Stop) => {
-                                if let Err(err) = pipeline_tx.send(Message::Stop).await {
-                                    warn!("Failed to forward shell stop message to pipeline: {}", err);
-                                }
                                 info!("Stop message received, shutting down shell worker");
                                 break;
                             }
@@ -233,7 +231,7 @@ impl InputLauncher for ShellInstance {
             }
         });
 
-        Ok(tx)
+        Ok(ComponentRuntime { tx, task })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,30 @@ use crate::remote::RemoteBuilder;
 use anyhow::Context;
 use log::info;
 
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> anyhow::Result<&'static str> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigterm =
+        signal(SignalKind::terminate()).context("Failed to listen for SIGTERM")?;
+
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result.context("Failed to listen for Ctrl+C")?;
+            Ok("Ctrl+C")
+        }
+        _ = sigterm.recv() => Ok("SIGTERM"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> anyhow::Result<&'static str> {
+    tokio::signal::ctrl_c()
+        .await
+        .context("Failed to listen for Ctrl+C")?;
+    Ok("Ctrl+C")
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
@@ -45,12 +69,10 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     info!("Pipeline runtime started");
 
-    info!("Waiting for Ctrl+C");
-    tokio::signal::ctrl_c()
-        .await
-        .context("Failed to listen for Ctrl+C")?;
+    info!("Waiting for shutdown signal");
+    let signal = wait_for_shutdown_signal().await?;
 
-    info!("Ctrl+C received, sending stop messages");
+    info!("{} received, sending stop messages", signal);
     runtime.stop().await;
     info!("Shutdown complete");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,7 @@ use log::info;
 async fn wait_for_shutdown_signal() -> anyhow::Result<&'static str> {
     use tokio::signal::unix::{SignalKind, signal};
 
-    let mut sigterm =
-        signal(SignalKind::terminate()).context("Failed to listen for SIGTERM")?;
+    let mut sigterm = signal(SignalKind::terminate()).context("Failed to listen for SIGTERM")?;
 
     tokio::select! {
         result = tokio::signal::ctrl_c() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod input;
 mod message;
 mod pipeline;
 mod remote;
+mod runtime;
 
 use crate::cfg::parse_config_file;
 use crate::input::InputBuilder;

--- a/src/message.rs
+++ b/src/message.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use bytes::Bytes;
+#[cfg(any(feature = "ros1", feature = "ros2"))]
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -25,6 +26,7 @@ pub struct Record {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(any(feature = "ros1", feature = "ros2"))]
 pub struct Attachment {
     pub entry_name: String,
     pub key: String,
@@ -34,6 +36,7 @@ pub struct Attachment {
 #[derive(Debug, Clone)]
 pub enum Message {
     Data(Record),
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
     Attachment(Attachment),
     Stop,
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -21,12 +21,9 @@ use log::{debug, info, warn};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc::{Sender, channel};
-use tokio::time::{Duration, Instant, timeout};
 use toml::Value;
 
 const CHANNEL_SIZE: usize = 1024;
-const COMPONENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
-const GLOBAL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone)]
 struct NamedPipelineConfig {
@@ -211,7 +208,6 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
     async fn launch(&self, remote_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
         let pipeline_name = self.pipeline_name.clone();
-        let runtime_name = pipeline_name.clone();
         let preprocess_keys: Vec<String> = self.preprocess.keys().cloned().collect();
         let mut label_rules: Vec<PipelineLabelRuleRuntime> = self
             .label_rules
@@ -261,12 +257,7 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
             }
         });
 
-        Ok(ComponentRuntime {
-            name: runtime_name,
-            kind: "pipeline",
-            tx,
-            task,
-        })
+        Ok(ComponentRuntime { tx, task })
     }
 
     fn input_names(&self) -> &[String] {
@@ -276,61 +267,37 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
 
 pub struct PipelineRuntime {
     inputs: Vec<ComponentRuntime>,
-    fanouts: Vec<ComponentRuntime>,
+    input_routers: Vec<ComponentRuntime>,
     pipelines: Vec<ComponentRuntime>,
     remotes: Vec<ComponentRuntime>,
 }
 
 impl PipelineRuntime {
-    async fn stop_stage(stage: Vec<ComponentRuntime>, deadline: Instant) {
+    async fn stop_stage(stage: Vec<ComponentRuntime>) {
         let mut pending = stage;
         for component in &pending {
             if let Err(err) = component.tx.send(Message::Stop).await {
-                debug!(
-                    "Failed to send stop to {} '{}': {}",
-                    component.kind, component.name, err
-                );
+                debug!("Failed to send stop to component: {}", err);
             }
         }
 
         while let Some(component) = pending.pop() {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                warn!(
-                    "Global shutdown timeout reached before {} '{}' finished",
-                    component.kind, component.name
-                );
-                component.task.abort();
-                continue;
-            }
-
-            let wait_for = remaining.min(COMPONENT_SHUTDOWN_TIMEOUT);
-            match timeout(wait_for, component.task).await {
-                Ok(Ok(())) => {
-                    debug!("{} '{}' stopped cleanly", component.kind, component.name);
+            match component.task.await {
+                Ok(()) => {
+                    debug!("Component stopped cleanly");
                 }
-                Ok(Err(err)) => {
-                    warn!(
-                        "{} '{}' failed during shutdown: {}",
-                        component.kind, component.name, err
-                    );
-                }
-                Err(_) => {
-                    warn!(
-                        "Timed out waiting for {} '{}' to stop",
-                        component.kind, component.name
-                    );
+                Err(err) => {
+                    warn!("Component failed during shutdown: {}", err);
                 }
             }
         }
     }
 
     pub async fn stop(self) {
-        let deadline = Instant::now() + GLOBAL_SHUTDOWN_TIMEOUT;
-        Self::stop_stage(self.inputs, deadline).await;
-        Self::stop_stage(self.fanouts, deadline).await;
-        Self::stop_stage(self.pipelines, deadline).await;
-        Self::stop_stage(self.remotes, deadline).await;
+        Self::stop_stage(self.inputs).await;
+        Self::stop_stage(self.input_routers).await;
+        Self::stop_stage(self.pipelines).await;
+        Self::stop_stage(self.remotes).await;
     }
 }
 
@@ -395,7 +362,7 @@ impl PipelineBuilder {
         }
 
         let mut inputs: Vec<ComponentRuntime> = Vec::new();
-        let mut fanouts: Vec<ComponentRuntime> = Vec::new();
+        let mut input_routers: Vec<ComponentRuntime> = Vec::new();
         let mut input_names: HashSet<String> = HashSet::new();
         for cfg in &pipeline_configs {
             for input_name in &cfg.inputs {
@@ -412,15 +379,14 @@ impl PipelineBuilder {
                 );
             }
 
-            let (fanout_tx, mut fanout_rx) = channel::<Message>(CHANNEL_SIZE);
+            let (input_router_tx, mut input_router_rx) = channel::<Message>(CHANNEL_SIZE);
             let route_name = input_name.clone();
-            let fanout_runtime_name = route_name.clone();
-            let fanout_task = tokio::spawn(async move {
-                debug!("Fan-out worker started for input '{}'", route_name);
-                while let Some(message) = fanout_rx.recv().await {
+            let input_router_task = tokio::spawn(async move {
+                debug!("Input router started for input '{}'", route_name);
+                while let Some(message) = input_router_rx.recv().await {
                     match message {
                         Message::Stop => {
-                            info!("Fan-out worker for input '{}' stopping", route_name);
+                            info!("Input router for input '{}' stopping", route_name);
                             break;
                         }
                         other => {
@@ -436,21 +402,19 @@ impl PipelineBuilder {
                     }
                 }
             });
-            fanouts.push(ComponentRuntime {
-                name: fanout_runtime_name,
-                kind: "fanout",
-                tx: fanout_tx.clone(),
-                task: fanout_task,
+            input_routers.push(ComponentRuntime {
+                tx: input_router_tx.clone(),
+                task: input_router_task,
             });
 
-            let input = input_builder.build(config, &input_name, fanout_tx).await?;
+            let input = input_builder.build(config, &input_name, input_router_tx).await?;
             info!("Input '{}' launcher started", input_name);
             inputs.push(input);
         }
 
         Ok(PipelineRuntime {
             inputs,
-            fanouts,
+            input_routers,
             pipelines,
             remotes,
         })

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -21,9 +21,12 @@ use log::{debug, info, warn};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc::{Sender, channel};
+use tokio::time::{Duration, Instant, timeout};
 use toml::Value;
 
 const CHANNEL_SIZE: usize = 1024;
+const COMPONENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const GLOBAL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone)]
 struct NamedPipelineConfig {
@@ -208,6 +211,7 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
     async fn launch(&self, remote_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
         let pipeline_name = self.pipeline_name.clone();
+        let runtime_name = pipeline_name.clone();
         let preprocess_keys: Vec<String> = self.preprocess.keys().cloned().collect();
         let mut label_rules: Vec<PipelineLabelRuleRuntime> = self
             .label_rules
@@ -257,7 +261,12 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
             }
         });
 
-        Ok(ComponentRuntime { tx, task })
+        Ok(ComponentRuntime {
+            name: runtime_name,
+            kind: "pipeline",
+            tx,
+            task,
+        })
     }
 
     fn input_names(&self) -> &[String] {
@@ -273,22 +282,55 @@ pub struct PipelineRuntime {
 }
 
 impl PipelineRuntime {
-    async fn stop_stage(stage: Vec<ComponentRuntime>) {
+    async fn stop_stage(stage: Vec<ComponentRuntime>, deadline: Instant) {
         let mut pending = stage;
         for component in &pending {
-            let _ = component.tx.send(Message::Stop).await;
+            if let Err(err) = component.tx.send(Message::Stop).await {
+                debug!(
+                    "Failed to send stop to {} '{}': {}",
+                    component.kind, component.name, err
+                );
+            }
         }
 
         while let Some(component) = pending.pop() {
-            let _ = component.task.await;
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                warn!(
+                    "Global shutdown timeout reached before {} '{}' finished",
+                    component.kind, component.name
+                );
+                component.task.abort();
+                continue;
+            }
+
+            let wait_for = remaining.min(COMPONENT_SHUTDOWN_TIMEOUT);
+            match timeout(wait_for, component.task).await {
+                Ok(Ok(())) => {
+                    debug!("{} '{}' stopped cleanly", component.kind, component.name);
+                }
+                Ok(Err(err)) => {
+                    warn!(
+                        "{} '{}' failed during shutdown: {}",
+                        component.kind, component.name, err
+                    );
+                }
+                Err(_) => {
+                    warn!(
+                        "Timed out waiting for {} '{}' to stop",
+                        component.kind, component.name
+                    );
+                }
+            }
         }
     }
 
     pub async fn stop(self) {
-        Self::stop_stage(self.inputs).await;
-        Self::stop_stage(self.fanouts).await;
-        Self::stop_stage(self.pipelines).await;
-        Self::stop_stage(self.remotes).await;
+        let deadline = Instant::now() + GLOBAL_SHUTDOWN_TIMEOUT;
+        Self::stop_stage(self.inputs, deadline).await;
+        Self::stop_stage(self.fanouts, deadline).await;
+        Self::stop_stage(self.pipelines, deadline).await;
+        Self::stop_stage(self.remotes, deadline).await;
     }
 }
 
@@ -372,6 +414,7 @@ impl PipelineBuilder {
 
             let (fanout_tx, mut fanout_rx) = channel::<Message>(CHANNEL_SIZE);
             let route_name = input_name.clone();
+            let fanout_runtime_name = route_name.clone();
             let fanout_task = tokio::spawn(async move {
                 debug!("Fan-out worker started for input '{}'", route_name);
                 while let Some(message) = fanout_rx.recv().await {
@@ -394,6 +437,8 @@ impl PipelineBuilder {
                 }
             });
             fanouts.push(ComponentRuntime {
+                name: fanout_runtime_name,
+                kind: "fanout",
                 tx: fanout_tx.clone(),
                 task: fanout_task,
             });

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -468,6 +468,7 @@ mod tests {
     use crate::message::Message;
     use crate::runtime::ComponentRuntime;
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::sync::mpsc::channel;
     use tokio::time::{Duration, sleep, timeout};
@@ -523,6 +524,66 @@ mod tests {
         assert!(
             completed.load(Ordering::SeqCst),
             "component should complete before shutdown returns"
+        );
+    }
+
+    fn ordered_component(
+        name: &'static str,
+        delay: Duration,
+        events: Arc<Mutex<Vec<&'static str>>>,
+    ) -> ComponentRuntime {
+        let (tx, mut rx) = channel::<Message>(8);
+        let task = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                if matches!(message, Message::Stop) {
+                    events.lock().expect("events lock").push(match name {
+                        "input" => "input_stop_received",
+                        "pipeline" => "pipeline_stop_received",
+                        _ => "unknown_stop_received",
+                    });
+                    sleep(delay).await;
+                    events.lock().expect("events lock").push(match name {
+                        "input" => "input_completed",
+                        "pipeline" => "pipeline_completed",
+                        _ => "unknown_completed",
+                    });
+                    break;
+                }
+            }
+        });
+
+        ComponentRuntime { tx, task }
+    }
+
+    #[tokio::test]
+    async fn stop_shuts_down_stages_in_order() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let runtime = PipelineRuntime {
+            inputs: vec![ordered_component(
+                "input",
+                Duration::from_millis(100),
+                Arc::clone(&events),
+            )],
+            input_routers: vec![],
+            pipelines: vec![ordered_component(
+                "pipeline",
+                Duration::from_millis(10),
+                Arc::clone(&events),
+            )],
+            remotes: vec![],
+        };
+
+        runtime.stop().await;
+
+        let events = events.lock().expect("events lock");
+        assert_eq!(
+            events.as_slice(),
+            [
+                "input_stop_received",
+                "input_completed",
+                "pipeline_stop_received",
+                "pipeline_completed",
+            ]
         );
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -241,6 +241,7 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
                             );
                         }
                     }
+                    #[cfg(any(feature = "ros1", feature = "ros2"))]
                     Message::Attachment(attachment) => {
                         if let Err(err) = remote_tx.send(Message::Attachment(attachment)).await {
                             warn!(

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -407,7 +407,9 @@ impl PipelineBuilder {
                 task: input_router_task,
             });
 
-            let input = input_builder.build(config, &input_name, input_router_tx).await?;
+            let input = input_builder
+                .build(config, &input_name, input_router_tx)
+                .await?;
             info!("Input '{}' launcher started", input_name);
             inputs.push(input);
         }
@@ -458,4 +460,69 @@ fn parse_pipeline_configs(config: &Value) -> Result<Vec<NamedPipelineConfig>, Er
     }
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PipelineRuntime;
+    use crate::message::Message;
+    use crate::runtime::ComponentRuntime;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::mpsc::channel;
+    use tokio::time::{Duration, sleep, timeout};
+
+    fn delayed_component(delay: Duration, completed: Arc<AtomicBool>) -> ComponentRuntime {
+        let (tx, mut rx) = channel::<Message>(8);
+        let task = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                if matches!(message, Message::Stop) {
+                    sleep(delay).await;
+                    completed.store(true, Ordering::SeqCst);
+                    break;
+                }
+            }
+        });
+
+        ComponentRuntime { tx, task }
+    }
+
+    #[tokio::test]
+    async fn stop_waits_for_component_completion() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let runtime = PipelineRuntime {
+            inputs: vec![delayed_component(
+                Duration::from_millis(150),
+                Arc::clone(&completed),
+            )],
+            input_routers: vec![],
+            pipelines: vec![],
+            remotes: vec![],
+        };
+
+        let stop_task = tokio::spawn(async move {
+            runtime.stop().await;
+        });
+        tokio::pin!(stop_task);
+
+        assert!(
+            timeout(Duration::from_millis(50), &mut stop_task)
+                .await
+                .is_err(),
+            "shutdown should still be waiting for component completion"
+        );
+        assert!(
+            !completed.load(Ordering::SeqCst),
+            "component should not have finished yet"
+        );
+
+        timeout(Duration::from_millis(300), &mut stop_task)
+            .await
+            .expect("shutdown should complete after component finishes")
+            .expect("shutdown task should finish cleanly");
+        assert!(
+            completed.load(Ordering::SeqCst),
+            "component should complete before shutdown returns"
+        );
+    }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,6 +14,7 @@
 use crate::input::InputBuilder;
 use crate::message::{Message, Record};
 use crate::remote::RemoteBuilder;
+use crate::runtime::ComponentRuntime;
 use anyhow::{Context, Error, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -79,7 +80,7 @@ struct PipelineConfig {
 
 #[async_trait]
 pub trait PipelineLauncher: Send + Sync {
-    async fn launch(&self, remote_tx: Sender<Message>) -> Result<Sender<Message>, Error>;
+    async fn launch(&self, remote_tx: Sender<Message>) -> Result<ComponentRuntime, Error>;
     fn input_names(&self) -> &[String];
 }
 
@@ -204,7 +205,7 @@ fn apply_label_rules(record: &mut Record, rules: &mut [PipelineLabelRuleRuntime]
 
 #[async_trait]
 impl PipelineLauncher for PassthroughPipelineLauncher {
-    async fn launch(&self, remote_tx: Sender<Message>) -> Result<Sender<Message>, Error> {
+    async fn launch(&self, remote_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
         let pipeline_name = self.pipeline_name.clone();
         let preprocess_keys: Vec<String> = self.preprocess.keys().cloned().collect();
@@ -221,7 +222,7 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
             preprocess_keys.len(),
             label_rules.len()
         );
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             debug!(
                 "Pipeline worker started for '{}' preprocess fields: {:?} label rules: {}",
                 pipeline_name,
@@ -230,29 +231,33 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
             );
 
             while let Some(message) = rx.recv().await {
-                let outbound = match message {
+                match message {
                     Message::Data(mut record) => {
                         apply_label_rules(&mut record, &mut label_rules);
-                        Message::Data(record)
+                        if let Err(err) = remote_tx.send(Message::Data(record)).await {
+                            warn!(
+                                "Failed to forward message from pipeline '{}' to remote: {}",
+                                pipeline_name, err
+                            );
+                        }
                     }
-                    other => other,
-                };
-
-                if let Err(err) = remote_tx.send(outbound.clone()).await {
-                    warn!(
-                        "Failed to forward message from pipeline '{}' to remote: {}",
-                        pipeline_name, err
-                    );
-                }
-
-                if matches!(outbound, Message::Stop) {
-                    info!("Stop received, shutting down pipeline '{}'", pipeline_name);
-                    break;
+                    Message::Attachment(attachment) => {
+                        if let Err(err) = remote_tx.send(Message::Attachment(attachment)).await {
+                            warn!(
+                                "Failed to forward message from pipeline '{}' to remote: {}",
+                                pipeline_name, err
+                            );
+                        }
+                    }
+                    Message::Stop => {
+                        info!("Stop received, shutting down pipeline '{}'", pipeline_name);
+                        break;
+                    }
                 }
             }
         });
 
-        Ok(tx)
+        Ok(ComponentRuntime { tx, task })
     }
 
     fn input_names(&self) -> &[String] {
@@ -261,22 +266,29 @@ impl PipelineLauncher for PassthroughPipelineLauncher {
 }
 
 pub struct PipelineRuntime {
-    input_txs: Vec<Sender<Message>>,
-    pipeline_txs: Vec<Sender<Message>>,
-    remote_txs: Vec<Sender<Message>>,
+    inputs: Vec<ComponentRuntime>,
+    fanouts: Vec<ComponentRuntime>,
+    pipelines: Vec<ComponentRuntime>,
+    remotes: Vec<ComponentRuntime>,
 }
 
 impl PipelineRuntime {
-    pub async fn stop(&self) {
-        for tx in &self.input_txs {
-            let _ = tx.send(Message::Stop).await;
+    async fn stop_stage(stage: Vec<ComponentRuntime>) {
+        let mut pending = stage;
+        for component in &pending {
+            let _ = component.tx.send(Message::Stop).await;
         }
-        for tx in &self.pipeline_txs {
-            let _ = tx.send(Message::Stop).await;
+
+        while let Some(component) = pending.pop() {
+            let _ = component.task.await;
         }
-        for tx in &self.remote_txs {
-            let _ = tx.send(Message::Stop).await;
-        }
+    }
+
+    pub async fn stop(self) {
+        Self::stop_stage(self.inputs).await;
+        Self::stop_stage(self.fanouts).await;
+        Self::stop_stage(self.pipelines).await;
+        Self::stop_stage(self.remotes).await;
     }
 }
 
@@ -297,21 +309,21 @@ impl PipelineBuilder {
         info!("Discovered {} pipeline entries", pipeline_configs.len());
 
         let mut remote_txs_by_name: HashMap<String, Sender<Message>> = HashMap::new();
-        let mut remote_txs: Vec<Sender<Message>> = Vec::new();
+        let mut remotes: Vec<ComponentRuntime> = Vec::new();
         let mut remote_names: HashSet<String> = HashSet::new();
         for cfg in &pipeline_configs {
             remote_names.insert(cfg.remote.clone());
         }
 
         for remote_name in remote_names {
-            let remote_tx = remote_builder.build(config, &remote_name).await?;
+            let remote = remote_builder.build(config, &remote_name).await?;
             info!("Remote '{}' launcher started", remote_name);
-            remote_txs.push(remote_tx.clone());
-            remote_txs_by_name.insert(remote_name, remote_tx);
+            remote_txs_by_name.insert(remote_name, remote.tx.clone());
+            remotes.push(remote);
         }
 
         let mut pipeline_routes: HashMap<String, Vec<Sender<Message>>> = HashMap::new();
-        let mut pipeline_txs: Vec<Sender<Message>> = Vec::new();
+        let mut pipelines: Vec<ComponentRuntime> = Vec::new();
 
         for cfg in &pipeline_configs {
             let remote_tx = remote_txs_by_name
@@ -330,17 +342,18 @@ impl PipelineBuilder {
                 cfg.labels.clone(),
                 cfg.preprocess.clone(),
             );
-            let pipeline_tx = launcher.launch(remote_tx).await?;
-            pipeline_txs.push(pipeline_tx.clone());
+            let pipeline = launcher.launch(remote_tx).await?;
             for input_name in launcher.input_names() {
                 pipeline_routes
                     .entry(input_name.clone())
                     .or_default()
-                    .push(pipeline_tx.clone());
+                    .push(pipeline.tx.clone());
             }
+            pipelines.push(pipeline);
         }
 
-        let mut input_txs: Vec<Sender<Message>> = Vec::new();
+        let mut inputs: Vec<ComponentRuntime> = Vec::new();
+        let mut fanouts: Vec<ComponentRuntime> = Vec::new();
         let mut input_names: HashSet<String> = HashSet::new();
         for cfg in &pipeline_configs {
             for input_name in &cfg.inputs {
@@ -359,34 +372,42 @@ impl PipelineBuilder {
 
             let (fanout_tx, mut fanout_rx) = channel::<Message>(CHANNEL_SIZE);
             let route_name = input_name.clone();
-            tokio::spawn(async move {
+            let fanout_task = tokio::spawn(async move {
                 debug!("Fan-out worker started for input '{}'", route_name);
                 while let Some(message) = fanout_rx.recv().await {
-                    for tx in &route_txs {
-                        if let Err(err) = tx.send(message.clone()).await {
-                            warn!(
-                                "Failed to route message from input '{}' to pipeline: {}",
-                                route_name, err
-                            );
+                    match message {
+                        Message::Stop => {
+                            info!("Fan-out worker for input '{}' stopping", route_name);
+                            break;
                         }
-                    }
-
-                    if matches!(message, Message::Stop) {
-                        info!("Fan-out worker for input '{}' stopping", route_name);
-                        break;
+                        other => {
+                            for tx in &route_txs {
+                                if let Err(err) = tx.send(other.clone()).await {
+                                    warn!(
+                                        "Failed to route message from input '{}' to pipeline: {}",
+                                        route_name, err
+                                    );
+                                }
+                            }
+                        }
                     }
                 }
             });
+            fanouts.push(ComponentRuntime {
+                tx: fanout_tx.clone(),
+                task: fanout_task,
+            });
 
-            let input_tx = input_builder.build(config, &input_name, fanout_tx).await?;
+            let input = input_builder.build(config, &input_name, fanout_tx).await?;
             info!("Input '{}' launcher started", input_name);
-            input_txs.push(input_tx);
+            inputs.push(input);
         }
 
         Ok(PipelineRuntime {
-            input_txs,
-            pipeline_txs,
-            remote_txs,
+            inputs,
+            fanouts,
+            pipelines,
+            remotes,
         })
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -14,16 +14,15 @@
 mod reduct;
 
 use crate::cfg::{find_named_entry, parse_entry};
-use crate::message::Message;
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, bail};
 use async_trait::async_trait;
 use log::debug;
-use tokio::sync::mpsc::Sender;
 use toml::Value;
 
 #[async_trait]
 pub trait RemoteInstanceLauncher: Send + Sync {
-    async fn launch(&self) -> Result<Sender<Message>, Error>;
+    async fn launch(&self) -> Result<ComponentRuntime, Error>;
 }
 
 pub struct RemoteBuilder;
@@ -33,7 +32,11 @@ impl RemoteBuilder {
         Self
     }
 
-    pub async fn build(&self, config: &Value, remote_name: &str) -> Result<Sender<Message>, Error> {
+    pub async fn build(
+        &self,
+        config: &Value,
+        remote_name: &str,
+    ) -> Result<ComponentRuntime, Error> {
         let (remote_type, remote_table) = find_named_entry(config, "remotes", remote_name)?;
         debug!(
             "Selected remote '{}' from dynamic section type '{}'",

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -180,7 +180,6 @@ impl RemoteInstanceLauncher for ReductInstance {
             cfg.batch_max_interval_ms
         );
 
-        let runtime_name = format!("{}:{}", cfg.url, cfg.bucket);
         let task = tokio::spawn(async move {
             debug!("Reduct worker task started for {}", cfg.url);
             let mut batch = bucket.write_record_batch();
@@ -225,12 +224,7 @@ impl RemoteInstanceLauncher for ReductInstance {
             }
         });
 
-        Ok(ComponentRuntime {
-            name: runtime_name,
-            kind: "remote",
-            tx,
-            task,
-        })
+        Ok(ComponentRuntime { tx, task })
     }
 }
 

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::message::{Attachment, Message, Record};
+#[cfg(any(feature = "ros1", feature = "ros2"))]
+use crate::message::Attachment;
+use crate::message::{Message, Record};
 use crate::remote::RemoteInstanceLauncher;
 use crate::runtime::ComponentRuntime;
 use anyhow::{Error, anyhow, bail};
@@ -128,6 +130,7 @@ impl ReductInstance {
         }
     }
 
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
     async fn write_attachment(cfg: &RemoteConfig, bucket: &Bucket, attachment: Attachment) {
         let Some(entry) = Self::normalize_entry_path(&cfg.prefix, &attachment.entry_name) else {
             warn!(
@@ -200,6 +203,7 @@ impl RemoteInstanceLauncher for ReductInstance {
                                     }
                                 }
                             }
+                            #[cfg(any(feature = "ros1", feature = "ros2"))]
                             Some(Message::Attachment(attachment)) => {
                                 Self::write_attachment(&cfg, &bucket, attachment).await;
                             }
@@ -231,7 +235,9 @@ impl RemoteInstanceLauncher for ReductInstance {
 #[cfg(all(test, feature = "ci"))]
 mod tests {
     use super::{ReductInstance, RemoteConfig};
-    use crate::message::{Attachment, Message, Record};
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    use crate::message::Attachment;
+    use crate::message::{Message, Record};
     use crate::remote::RemoteInstanceLauncher;
     use bytes::Bytes;
     use futures_util::StreamExt;
@@ -301,6 +307,7 @@ mod tests {
         })
     }
 
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
     #[fixture]
     fn ros_attachment_message() -> Message {
         Message::Attachment(Attachment {
@@ -330,6 +337,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
     async fn docker_reductstore_roundtrip_data_and_attachment(
         data_message: Message,
         ros_attachment_message: Message,

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -180,6 +180,7 @@ impl RemoteInstanceLauncher for ReductInstance {
             cfg.batch_max_interval_ms
         );
 
+        let runtime_name = format!("{}:{}", cfg.url, cfg.bucket);
         let task = tokio::spawn(async move {
             debug!("Reduct worker task started for {}", cfg.url);
             let mut batch = bucket.write_record_batch();
@@ -224,7 +225,12 @@ impl RemoteInstanceLauncher for ReductInstance {
             }
         });
 
-        Ok(ComponentRuntime { tx, task })
+        Ok(ComponentRuntime {
+            name: runtime_name,
+            kind: "remote",
+            tx,
+            task,
+        })
     }
 }
 

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 use crate::message::{Attachment, Message, Record};
 use crate::remote::RemoteInstanceLauncher;
+use crate::runtime::ComponentRuntime;
 use anyhow::{Error, anyhow, bail};
 use log::{debug, info, warn};
 use reduct_rs::{Bucket, RecordBuilder, ReductClient, WriteRecordBatchBuilder};
 use serde::Deserialize;
-use tokio::sync::mpsc::{Sender, channel};
+use tokio::sync::mpsc::channel;
 use tokio::time::{Duration, MissedTickBehavior, interval};
 
 const CHANNEL_SIZE: usize = 1024;
@@ -146,7 +147,7 @@ impl ReductInstance {
 
 #[async_trait::async_trait]
 impl RemoteInstanceLauncher for ReductInstance {
-    async fn launch(&self) -> Result<Sender<Message>, Error> {
+    async fn launch(&self) -> Result<ComponentRuntime, Error> {
         let cfg = self.cfg.clone();
         if cfg.batch_max_records == 0 {
             bail!("Reduct remote batch_max_records must be greater than 0");
@@ -179,7 +180,7 @@ impl RemoteInstanceLauncher for ReductInstance {
             cfg.batch_max_interval_ms
         );
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             debug!("Reduct worker task started for {}", cfg.url);
             let mut batch = bucket.write_record_batch();
             let mut flush_ticker = interval(Duration::from_millis(cfg.batch_max_interval_ms));
@@ -223,7 +224,7 @@ impl RemoteInstanceLauncher for ReductInstance {
             }
         });
 
-        Ok(tx)
+        Ok(ComponentRuntime { tx, task })
     }
 }
 
@@ -389,14 +390,16 @@ mod tests {
             batch_max_interval_ms: 50,
         });
 
-        let tx = remote.launch().await.expect("launch remote");
-        tx.send(data_message).await.expect("send data");
-        tx.send(ros_attachment_message)
+        let runtime = remote.launch().await.expect("launch remote");
+        runtime.tx.send(data_message).await.expect("send data");
+        runtime
+            .tx
+            .send(ros_attachment_message)
             .await
             .expect("send attachment");
 
-        tx.send(Message::Stop).await.expect("send stop");
-        sleep(Duration::from_millis(400)).await;
+        runtime.tx.send(Message::Stop).await.expect("send stop");
+        runtime.task.await.expect("join remote");
 
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         let mut query = bucket.query("it/entry").send().await.expect("query");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,8 +18,6 @@ use tokio::task::JoinHandle;
 
 #[derive(Debug)]
 pub struct ComponentRuntime {
-    pub name: String,
-    pub kind: &'static str,
     pub tx: Sender<Message>,
     pub task: JoinHandle<()>,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,23 @@
+// Copyright 2026 ReductSoftware UG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::message::Message;
+use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
+
+#[derive(Debug)]
+pub struct ComponentRuntime {
+    pub tx: Sender<Message>,
+    pub task: JoinHandle<()>,
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,6 +18,8 @@ use tokio::task::JoinHandle;
 
 #[derive(Debug)]
 pub struct ComponentRuntime {
+    pub name: String,
+    pub kind: &'static str,
     pub tx: Sender<Message>,
     pub task: JoinHandle<()>,
 }


### PR DESCRIPTION
Closes #21

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- added a shared `ComponentRuntime` wrapper to keep each component control channel together with its `JoinHandle`
- updated input, pipeline, and remote launchers to return tracked runtimes instead of only senders
- changed `PipelineRuntime` to own inputs, fan-outs, pipelines, and remotes and shut them down in stages
- stopped forwarding downstream `Message::Stop` from individual inputs and pipelines so shared consumers are not terminated early
- updated direct launcher tests to use the new runtime wrapper and verify clean task shutdown

### Related issues

- #21 Bridge shutdown sends Stop but does not wait for component completion

### Does this PR introduce a breaking change?

No user-facing breaking change is intended. This changes internal shutdown coordination only.

### Other information:

Validation:
- `cargo test`
