### PR TITLE
chore: enforce least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
       - CHANGELOG.md
 
 permissions:
-  id-token: write
   contents: read
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Hardened GitHub Actions token permissions by removing global `id-token: write` and keeping elevated `contents: write` only on release/upload jobs.
-
 ## 0.1.2 - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Hardened GitHub Actions token permissions by removing global `id-token: write` and keeping elevated `contents: write` only on release/upload jobs.
+
 ## 0.1.2 - 2026-03-30
 
 ### Added


### PR DESCRIPTION
Closes #26

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Chore / CI hardening.

### What was changed?

- Removed global `id-token: write` from `.github/workflows/ci.yml`.
- Kept workflow default token scope at `contents: read`.
- Preserved explicit `contents: write` only on release/upload jobs that actually need it.

### Related issues

- https://github.com/reductstore/reduct-bridge/issues/26
- Approved implementation plan: https://github.com/reductstore/reduct-bridge/issues/26#issuecomment-4305299511

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run locally:
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`