### PR TITLE
docs(changelog): add missing entries for merged feature/fix PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MQTT input for MQTT v3/v5 with payload/topic labels and optional JSON-schema attachments, [PR-24](https://github.com/reductstore/reduct-bridge/pull/24)
+
 ## 0.1.2 - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MQTT input for MQTT v3/v5 with payload/topic labels and optional JSON-schema attachments, [PR-24](https://github.com/reductstore/reduct-bridge/pull/24)
 
+### Fixed
+
+- Deterministic bridge shutdown by tracking component tasks, [PR-22](https://github.com/reductstore/reduct-bridge/pull/22)
+
 ## 0.1.2 - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Metrics input for CPU, memory, and disk with JSON output and label mapping, [PR-19](https://github.com/reductstore/reduct-bridge/pull/19)
 - MQTT input for MQTT v3/v5 with payload/topic labels and optional JSON-schema attachments, [PR-24](https://github.com/reductstore/reduct-bridge/pull/24)
 
 ### Fixed


### PR DESCRIPTION
## Summary
- add missing changelog entries under Unreleased for merged PRs #19, #22, and #24
- classify entries by section: Added (PR #19, PR #24) and Fixed (PR #22)
- ensure changelog references the original PR links for traceability

## Testing
- docs-only change