### PR TITLE
ci: pin third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Rust Linter
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check code
         run: cargo fmt --all -- --check
 
@@ -70,7 +70,7 @@ jobs:
             ros_setup_script: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install ROS2
         if: ${{ matrix.ros_setup_script != '' }}
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
@@ -123,7 +123,7 @@ jobs:
       RUST_BACKTRACE: 1
       RUST_LOG: debug
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install ROS2
         if: ${{ matrix.ros_setup_script != '' }}
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
@@ -133,7 +133,7 @@ jobs:
         if: ${{ matrix.ros_setup_script != '' }}
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
       - name: Download test artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.artifact_prefix }}-tests-x86_64-unknown-linux-gnu
           path: ./tmp/tests
@@ -151,9 +151,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download reduct-bridge Linux artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bridge-ros1-x86_64-unknown-linux-gnu
           path: ./tmp/reduct-bridge
@@ -173,9 +173,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download reduct-bridge Linux artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bridge-ros1-x86_64-unknown-linux-gnu
           path: ./tmp/reduct-bridge
@@ -195,9 +195,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download reduct-bridge Linux artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bridge-iot-x86_64-unknown-linux-gnu
           path: ./tmp/reduct-bridge
@@ -232,7 +232,7 @@ jobs:
             ros_setup_script: "/opt/ros/humble/setup.bash"
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install ROS2
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
@@ -240,7 +240,7 @@ jobs:
       - name: Install ROS2 interface packages
         run: sudo apt-get update && sudo apt-get install -y ros-${{ matrix.ros_distro }}-example-interfaces ros-${{ matrix.ros_distro }}-test-msgs
       - name: Download reduct-bridge Linux artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.artifact_prefix }}-x86_64-unknown-linux-gnu
           path: ./tmp/reduct-bridge
@@ -261,7 +261,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_LOG: debug
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install ROS2
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
@@ -308,7 +308,7 @@ jobs:
             bridge_artifact_name: bridge-iot-x86_64-unknown-linux-gnu
             image_tag: reduct/bridge:iot-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/build-docker
         with:
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check tag
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -394,9 +394,9 @@ jobs:
           - artifact_name: bridge-iot-x86_64-unknown-linux-gnu
             asset_name: bridge-iot.x86_64-unknown-linux-gnu.tar.gz
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download ${{ matrix.artifact_name }} artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.artifact_name }}
           path: /tmp/
@@ -448,7 +448,7 @@ jobs:
             image_suffix: iot
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to the Container registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -487,7 +487,7 @@ jobs:
       matrix:
         variant: [ros1, ros2, iot]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: snap
         uses: ./.github/actions/snap-release
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             os: ubuntu-24.04
             ros_distro: ""
             ros_setup_script: ""
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       RUST_BACKTRACE: 1
       RUST_LOG: debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install ROS2
         if: ${{ matrix.ros_setup_script != '' }}
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install ROS2
         if: ${{ matrix.ros_setup_script != '' }}
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
@@ -233,7 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install ROS2
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
           required-ros-distributions: ${{ matrix.ros_distro }}
       - name: Install ROS2 interface packages
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install ROS2
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
           required-ros-distributions: jazzy
       - name: Install ROS2 interface packages
@@ -278,7 +278,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         continue-on-error: true
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           files: lcov.info
           fail_ci_if_error: true
@@ -361,7 +361,7 @@ jobs:
     name: Make release
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         id: create_release
         with:
           draft: true
@@ -450,7 +450,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -502,7 +502,7 @@ jobs:
           fi
       - name: Publish snap package
         if: ${{ steps.snapcraft-creds.outputs.available == 'true' }}
-        uses: snapcore/action-publish@master
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ permissions:
 env:
   REGISTRY_IMAGE: reduct/bridge
   AWS_LC_SYS_USE_PREBUILT: 0
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   rust_fmt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Deterministic bridge shutdown by tracking component tasks, [PR-22](https://github.com/reductstore/reduct-bridge/pull/22)
+- Pinned third-party GitHub Actions to immutable commit SHAs in CI workflow hardening, [PR-32](https://github.com/reductstore/reduct-bridge/pull/32)
 
 ## 0.1.2 - 2026-03-30
 


### PR DESCRIPTION
Closes #30

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI maintenance

### What was changed?

- Pinned third-party GitHub Actions in `.github/workflows/ci.yml` from floating refs to immutable commit SHAs:
  - `ros-tooling/setup-ros@v0.7` → `@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30`
  - `codecov/codecov-action@v4` → `@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238`
  - `softprops/action-gh-release@v2` → `@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`
  - `docker/login-action@v2` → `@465a07811f14bebb1938fbed4728c6a1ff8901fc`
  - `snapcore/action-publish@master` → `@214b86e5ca036ead1668c79afb81e550e6c54d40`
- Left first-party/local actions as-is (`actions/*` and `./.github/actions/*`) per scope.

### Related issues

- https://github.com/reductstore/reduct-bridge/issues/30
- https://github.com/reductstore/security/issues/22

### Does this PR introduce a breaking change?

No expected runtime breaking changes. This only affects CI workflow action resolution.

### Other information:

Implementation plan approval: https://github.com/reductstore/reduct-bridge/issues/30#issuecomment-4395747136
