### PR TITLE
Feat/15 http input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,14 @@ on:
       - "v*"
     paths-ignore:
       - docs/**
+      - dev/**
       - README.md
       - CHANGELOG.md
 
   pull_request:
     paths-ignore:
       - docs/**
+      - dev/**
       - README.md
       - CHANGELOG.md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Prevent apt upgrade from triggering snap store
+        if: ${{ matrix.ros_setup_script != '' }}
+        run: sudo apt-mark hold firefox snapd
       - name: Install ROS2
         if: ${{ matrix.ros_setup_script != '' }}
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
@@ -124,6 +127,9 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Prevent apt upgrade from triggering snap store
+        if: ${{ matrix.ros_setup_script != '' }}
+        run: sudo apt-mark hold firefox snapd
       - name: Install ROS2
         if: ${{ matrix.ros_setup_script != '' }}
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
@@ -236,6 +242,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Prevent apt upgrade from triggering snap store
+        run: sudo apt-mark hold firefox snapd
       - name: Install ROS2
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:
@@ -265,6 +273,8 @@ jobs:
       RUST_LOG: debug
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Prevent apt upgrade from triggering snap store
+        run: sudo apt-mark hold firefox snapd
       - name: Install ROS2
         uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- HTTP input for polling HTTP/HTTPS endpoints on a fixed interval with GET requests, optional bearer/basic auth, header/static/JSON field label mapping, and HTTP-specific tests and documentation, [PR-33](https://github.com/reductstore/reduct-bridge/pull/33).
 - Optional ReductStore bucket creation via `[remotes.reduct.create_bucket]`, with configurable `quota_type`, numeric or human-readable `quota_size` values such as `"1GB"` and `"4GiB"`, updated examples/docs, and parsing coverage for valid and invalid unit strings, [PR-34](https://github.com/reductstore/reduct-bridge/pull/34).
 - Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -807,6 +817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1031,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1166,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1175,9 +1211,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1588,6 +1626,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -2059,6 +2103,7 @@ dependencies = [
  "rclrs",
  "reduct-rs",
  "regex",
+ "reqwest 0.13.3",
  "ros2_message",
  "rosrust",
  "rstest",
@@ -2177,8 +2222,10 @@ dependencies = [
  "bytes",
  "cookie",
  "cookie_store",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2187,6 +2234,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2307,21 +2355,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -2449,7 +2496,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2536,7 +2583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2780,6 +2827,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3421,6 +3489,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2024"
 
 [features]
 default = ["shell"]
-all-inputs = ["shell", "ros1", "ros2", "metrics", "iot"]
+all-inputs = ["shell", "ros1", "ros2", "metrics", "http", "iot"]
 ros1 = ["dep:rosrust"]
 ros2 = ["dep:rclrs", "dep:ros2_message"]
 shell = []
 metrics = ["dep:systemstat"]
 mqtt = ["dep:rumqttc", "dep:rustls", "dep:prost-reflect", "dep:prost", "dep:base64"]
+http = ["dep:reqwest"]
 iot = ["mqtt"]
 ci = []
 
@@ -45,9 +46,13 @@ prost-reflect = { version = "0.14", optional = true, features = ["serde"] }
 prost = { version = "0.13", optional = true }
 base64 = { version = "0.22", optional = true }
 bytesize = { version = "2", features = ["serde"] }
+reqwest = { version = "0.13.3", optional = true, features = [
+  "json",
+  "rustls",
+] }
 
 [dev-dependencies]
-rstest = "0.25.0"
+rstest = "0.26.1"
 futures-util = "0.3.32"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ ros1 = ["dep:rosrust"]
 ros2 = ["dep:rclrs", "dep:ros2_message"]
 shell = []
 metrics = ["dep:systemstat"]
-mqtt = ["dep:rumqttc", "dep:rustls", "dep:prost-reflect", "dep:prost", "dep:base64"]
+mqtt = [
+  "dep:rumqttc",
+  "dep:rustls",
+]
 http = ["dep:reqwest"]
-iot = ["mqtt"]
+iot = ["mqtt", "http"]
 ci = []
 
 
@@ -42,14 +45,11 @@ ros2_message = { git = "https://github.com/reductstore/ros2_message", optional =
 systemstat = { version = "0.2.6", optional = true }
 rumqttc = { version = "0.25.1", optional = true }
 rustls = { version = "0.23.37", optional = true, features = ["ring"] }
-prost-reflect = { version = "0.14", optional = true, features = ["serde"] }
-prost = { version = "0.13", optional = true }
-base64 = { version = "0.22", optional = true }
+prost-reflect = { version = "0.14", features = ["serde"] }
+prost = { version = "0.13" }
+base64 = { version = "0.22" }
 bytesize = { version = "2", features = ["serde"] }
-reqwest = { version = "0.13.3", optional = true, features = [
-  "json",
-  "rustls",
-] }
+reqwest = { version = "0.13.3", optional = true, features = ["json", "rustls"] }
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An `input` is a data source. It reads data from a system and produces records fo
 
 Supported input types include:
 
+- [HTTP](src/input/http/README.md) - poll HTTP/HTTPS endpoints on a fixed interval and store response payloads with optional JSON/header label mapping.
 - [Metrics](src/input/metrics/README.md) - collect host CPU, memory, and disk metrics as JSON records.
 - [MQTT](src/input/mqtt/README.md) - subscribe to MQTT v3/v5 topics over `mqtt://` or `mqtts://` and store raw payloads with optional payload/property label mapping.
 - [Shell](src/input/shell/README.md) - run shell commands on a fixed interval and store output lines as records.
@@ -95,6 +96,7 @@ cargo install reduct-bridge
 ```
 
 `cargo install reduct-bridge` builds the default feature set, which includes only the `shell` input.
+For HTTP-specific build and runtime guidance, see [HTTP input documentation](src/input/http/README.md).
 For MQTT-specific build and runtime guidance, see [MQTT input documentation](src/input/mqtt/README.md).
 The MQTT input is grouped under the `iot` Cargo feature alongside future IoT protocols.
 For metrics-specific build and runtime guidance, see [Metrics input documentation](src/input/metrics/README.md).
@@ -104,7 +106,7 @@ To build additional inputs explicitly from source:
 
 ```bash
 cargo build --no-default-features --features ros1
-cargo build --no-default-features --features shell,metrics,iot
+cargo build --no-default-features --features shell,metrics,http,iot
 cargo build --no-default-features --features all-inputs
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ReductBridge supports different payload formats.
 Support means ReductBridge can parse payloads, extract labels, and, when schema information is available, store that schema in ReductStore.
 
 - JSON: find values by field path (example: [examples/mqtt_config.toml](examples/mqtt_config.toml)).
+- HTTP input: poll HTTP/HTTPS endpoints and extract optional header/JSON labels (example: [examples/http_config.toml](examples/http_config.toml)).
 - Protobuf: find values by field path (with schema) or by field ID/type (example: [examples/mqtt_protobuf_config.toml](examples/mqtt_protobuf_config.toml)).
 - ROS formats: decode ROS message payloads for labels and store the payloads as records (example: [examples/ros_config.toml](examples/ros_config.toml)).
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,21 +1,24 @@
 # Dev Environment
 
-## Start
+Each subdirectory contains a self-contained `docker-compose.yml` and config for a specific input type.
+
+## MQTT
 
 ```sh
 cargo build --features mqtt
-cd dev && docker compose up -d
+docker compose -f dev/mqtt/docker-compose.yml up
 ```
 
-## Watch (auto-restart on rebuild)
-
-```sh
-cargo watch -x 'build --features mqtt' -s 'docker compose -f dev/docker-compose.yml restart bridge'
-```
-
-## Regenerate proto files
+### Regenerate proto files
 
 ```sh
 protoc --proto_path=dev/mqtt --include_imports --descriptor_set_out=dev/mqtt/factory.desc factory.proto
 protoc --proto_path=dev/mqtt --python_out=dev/mqtt factory.proto
+```
+
+## HTTP
+
+```sh
+cargo build --features http
+docker compose -f dev/http/docker-compose.yml up
 ```

--- a/dev/http/api.py
+++ b/dev/http/api.py
@@ -1,0 +1,35 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+import random
+import time
+
+
+class WeatherHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/weather":
+            data = {
+                "city": random.choice(["Berlin", "Munich", "Hamburg"]),
+                "temperature": round(random.uniform(-5, 35), 1),
+                "humidity": random.randint(30, 95),
+                "unit": "celsius",
+                "timestamp": time.time(),
+            }
+            body = json.dumps(data).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("X-Request-Id", f"req-{random.randint(1000,9999)}")
+            self.end_headers()
+            self.write = self.wfile.write
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        print(f"[api] {args[0]}")
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("0.0.0.0", 8080), WeatherHandler)
+    print("[api] Listening on :8080")
+    server.serve_forever()

--- a/dev/http/bridge.toml
+++ b/dev/http/bridge.toml
@@ -1,0 +1,35 @@
+# =============================================================================
+# REMOTES: destination bucket in ReductStore
+# =============================================================================
+
+[[remotes.reduct]]
+name = "local"
+url = "http://reductstore:8383"
+token_api = ""
+bucket = "http-test"
+prefix = ""
+
+# =============================================================================
+# INPUT: HTTP polling
+# Polls a local dummy API every 5 seconds and stores the JSON response.
+# =============================================================================
+
+[inputs.http.weather]
+url = "http://api:8080/weather"
+repeat_interval = 5
+entry_name = "http/weather"
+content_type = "application/json"
+
+labels = [
+  { field = "city", label = "city" },
+  { field = "unit", label = "unit" },
+  { static = { source = "http-poll" } }
+]
+
+# =============================================================================
+# PIPELINES
+# =============================================================================
+
+[pipelines.http]
+inputs = ["weather"]
+remote = "local"

--- a/dev/http/docker-compose.yml
+++ b/dev/http/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  reductstore:
+    image: reduct/store:main
+    ports:
+      - "8383:8383"
+    environment:
+      RS_BUCKET_A_NAME: http-test
+      RS_BUCKET_A_QUOTA_TYPE: FIFO
+      RS_BUCKET_A_QUOTA_SIZE: 100MB
+
+  api:
+    image: python:3.12-slim
+    volumes:
+      - ./api.py:/app/api.py:ro
+    command: ["python", "/app/api.py"]
+
+  bridge:
+    image: ubuntu:24.04
+    volumes:
+      - ../../target/debug/reduct-bridge:/usr/local/bin/reduct-bridge:ro
+      - ./bridge.toml:/etc/bridge.toml:ro
+      - /etc/ssl/certs:/etc/ssl/certs:ro
+    command: ["reduct-bridge", "/etc/bridge.toml"]
+    depends_on:
+      - reductstore
+      - api
+    restart: unless-stopped

--- a/dev/mqtt/docker-compose.yml
+++ b/dev/mqtt/docker-compose.yml
@@ -19,11 +19,11 @@ services:
     ports:
       - "1883:1883"
     volumes:
-      - ./mqtt/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
 
   publisher:
     build:
-      context: ./mqtt
+      context: .
       dockerfile: Dockerfile.proto
     depends_on:
       - mosquitto
@@ -31,7 +31,7 @@ services:
 
   publisher-json:
     build:
-      context: ./mqtt
+      context: .
       dockerfile: Dockerfile.json
     depends_on:
       - mosquitto
@@ -40,9 +40,9 @@ services:
   bridge:
     image: ubuntu:24.04
     volumes:
-      - ../target/debug/reduct-bridge:/usr/local/bin/reduct-bridge:ro
-      - ./mqtt/bridge.toml:/etc/bridge.toml:ro
-      - ./mqtt/factory.desc:/app/factory.desc:ro
+      - ../../target/debug/reduct-bridge:/usr/local/bin/reduct-bridge:ro
+      - ./bridge.toml:/etc/bridge.toml:ro
+      - ./factory.desc:/app/factory.desc:ro
       - /etc/ssl/certs:/etc/ssl/certs:ro
     command: ["reduct-bridge", "/etc/bridge.toml"]
     depends_on:

--- a/examples/http_config.toml
+++ b/examples/http_config.toml
@@ -1,0 +1,72 @@
+# ReductStore remote destination.
+[[remotes.reduct]]
+# Unique remote name referenced by pipelines.<name>.remote.
+name = "local"
+# ReductStore base URL.
+url = "http://localhost:8383"
+# API token used for authentication.
+token_api = "***"
+# Target bucket for all records from this remote.
+bucket = "my-bucket"
+# Required key prefix inside the bucket.
+prefix = ""
+# Optional: create the bucket on startup if it does not exist.
+# Omit this table to require the bucket to exist before starting reduct-bridge.
+# [remotes.reduct.create_bucket]
+# quota_type = "FIFO" # NONE, FIFO, or HARD
+# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+
+# HTTP input configuration.
+# Structure: [inputs.http.<input_name>]
+[inputs.http.metrics_api]
+# Required: endpoint URL.
+# Supported schemes: http, https
+url = "https://example.com/api/metrics"
+# Required: polling interval in seconds.
+# Must be > 0.
+repeat_interval = 10
+# Required: target entry name in remote bucket.
+entry_name = "http/metrics"
+# Optional: override content type written to ReductStore.
+# If omitted, the response Content-Type header is used when available.
+content_type = "application/json"
+# Optional bearer token authentication.
+bearer_token = "${HTTP_TOKEN}"
+# Optional label rules (default = []):
+# 1) Dynamic JSON field label:
+#    { field = "path.to.value", label = "label_name" }
+# 2) Response header label:
+#    { header = "x-request-id", label = "request_id" }
+# 3) Static labels:
+#    { static = { source = "http", site = "lab" } }
+labels = [
+  { field = "device.id", label = "device" },
+  { field = "site", label = "site" },
+  { header = "etag", label = "revision" },
+  { header = "x-request-id", label = "request_id" },
+  { static = { source = "http" } }
+]
+
+# Optional HTTP input using basic authentication.
+[inputs.http.status_api]
+url = "https://example.com/api/status"
+repeat_interval = 30
+entry_name = "http/status"
+labels = [
+  { header = "etag", label = "etag" },
+  { static = { source = "status_api" } }
+]
+
+[inputs.http.status_api.basic_auth]
+username = "bridge"
+password = "${HTTP_PASSWORD}"
+
+
+# Pipelines
+[pipelines.http_metrics]
+remote = "local"
+inputs = ["metrics_api"]
+
+[pipelines.http_status]
+remote = "local"
+inputs = ["status_api"]

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #[cfg(any(
+    feature = "http",
     feature = "metrics",
     feature = "mqtt",
     feature = "ros1",

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -12,15 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(any(
-    feature = "http",
-    feature = "metrics",
-    feature = "mqtt",
-    feature = "ros1",
-    feature = "ros2"
-))]
 pub mod json;
-#[cfg(feature = "mqtt")]
 pub mod protobuf;
 #[cfg(feature = "ros1")]
 pub mod ros1;
@@ -30,7 +22,6 @@ pub mod ros2;
 use anyhow::Result;
 use serde_json::Value;
 
-#[cfg(feature = "mqtt")]
 use anyhow::Context;
 
 #[derive(Clone, Copy)]
@@ -87,13 +78,11 @@ pub trait FormatHandler: Send + Sync {
     fn build_attachment(&self, context: AttachmentContext<'_>) -> Result<FormatAttachment>;
 }
 
-#[cfg(feature = "mqtt")]
 pub(crate) struct PayloadFormatHandler {
     json: crate::formats::json::JsonFormatHandler,
     protobuf: Option<crate::formats::protobuf::ProtobufHandler>,
 }
 
-#[cfg(feature = "mqtt")]
 impl PayloadFormatHandler {
     pub(crate) fn new(protobuf: Option<crate::formats::protobuf::ProtobufHandler>) -> Self {
         Self {
@@ -103,7 +92,6 @@ impl PayloadFormatHandler {
     }
 }
 
-#[cfg(feature = "mqtt")]
 impl FormatHandler for PayloadFormatHandler {
     fn decode_payload(&self, payload: &[u8], format: DecodeFormat<'_>) -> Option<Value> {
         match format {

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -1,22 +1,17 @@
 use serde_json::Value;
 
-#[cfg(feature = "mqtt")]
 use anyhow::{Result, bail};
 
-#[cfg(feature = "mqtt")]
 use super::{AttachmentContext, DecodeFormat, FormatAttachment, FormatHandler};
 
-#[cfg(feature = "mqtt")]
 pub(crate) struct JsonFormatHandler;
 
-#[cfg(feature = "mqtt")]
 impl JsonFormatHandler {
     pub(crate) fn decode(&self, payload: &[u8]) -> Option<Value> {
         serde_json::from_slice(payload).ok()
     }
 }
 
-#[cfg(feature = "mqtt")]
 impl FormatHandler for JsonFormatHandler {
     fn decode_payload(&self, payload: &[u8], format: DecodeFormat<'_>) -> Option<Value> {
         match format {

--- a/src/input.rs
+++ b/src/input.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "http")]
+mod http;
 #[cfg(feature = "metrics")]
 mod metrics;
 #[cfg(feature = "mqtt")]
@@ -90,6 +92,13 @@ impl InputBuilder {
                 let input_cfg: mqtt::MqttConfig = parse_entry(input_table)?;
                 debug!("Creating MQTT launcher for input '{}'", input_name);
                 let launcher = mqtt::MqttInstance::new(input_cfg);
+                launcher.launch(pipeline_tx).await
+            }
+            #[cfg(feature = "http")]
+            "http" => {
+                let input_cfg: http::HttpConfig = parse_entry(input_table)?;
+                debug!("Creating HTTP launcher for input '{}'", input_name);
+                let launcher = http::HttpInstance::new(input_cfg);
                 launcher.launch(pipeline_tx).await
             }
             _ => bail!(

--- a/src/input/http/README.md
+++ b/src/input/http/README.md
@@ -1,0 +1,92 @@
+# HTTP Input
+
+Use this input to poll an HTTP or HTTPS endpoint on a fixed interval and store each response.
+
+## Documented TOML Example
+
+```toml
+# Input definition path:
+# [inputs.http.<input_name>]
+[inputs.http.metrics_api]
+
+# Required: endpoint URL.
+# Supported schemes: http, https
+url = "https://example.com/api/metrics"
+
+# Required: polling interval in seconds.
+# Must be > 0.
+repeat_interval = 10
+
+# Optional: request method (default = "GET").
+method = "GET"
+
+# Required: target entry name in remote bucket.
+entry_name = "http/metrics"
+
+# Optional content type override for produced records.
+# If omitted, the response Content-Type header is used when available.
+content_type = "application/json"
+
+# Optional bearer token authentication.
+bearer_token = "${HTTP_TOKEN}"
+
+# Optional label rules (default = []):
+# 1) Dynamic JSON field label:
+#    { field = "path.to.value", label = "label_name" }
+#    - path uses dot notation; numeric segments are array indexes.
+# 2) Response header label:
+#    { header = "x-request-id", label = "request_id" }
+#    - header names are matched case-insensitively.
+# 3) Static labels:
+#    { static = { source = "http", site = "lab" } }
+# Merge behavior:
+# - rules are applied in order
+# - later writes for same key override earlier ones
+labels = [
+  { field = "device.id", label = "device" },
+  { header = "x-request-id", label = "request_id" },
+  { static = { source = "http" } }
+]
+```
+
+## Basic Authentication Example
+
+```toml
+[inputs.http.status_api]
+url = "https://example.com/api/status"
+repeat_interval = 30
+method = "GET"
+entry_name = "http/status"
+
+[inputs.http.status_api.basic_auth]
+username = "bridge"
+password = "${HTTP_PASSWORD}"
+
+labels = [
+  { header = "etag", label = "etag" },
+  { static = { source = "status_api" } }
+]
+```
+
+## Runtime Notes
+
+- Each successful poll produces one record.
+- Non-JSON responses are stored as raw response bytes.
+- JSON field labels are applied only when the response body can be parsed as JSON.
+- Failed requests and non-success HTTP statuses skip that polling cycle.
+- `entry_name` cannot be empty.
+- `repeat_interval` must be greater than zero.
+
+## Build
+
+Build only HTTP input support:
+
+```bash
+cargo build --no-default-features --features http
+```
+
+Build all inputs in one command:
+
+```bash
+cargo build --no-default-features --features all-inputs
+```

--- a/src/input/http/README.md
+++ b/src/input/http/README.md
@@ -20,6 +20,9 @@ repeat_interval = 10
 # Required: target entry name in remote bucket.
 entry_name = "http/metrics"
 
+# Optional HTTP method (default: GET).
+method = "GET"
+
 # Optional content type override for produced records.
 # If omitted, the response Content-Type header is used when available.
 content_type = "application/json"
@@ -53,21 +56,22 @@ labels = [
 url = "https://example.com/api/status"
 repeat_interval = 30
 entry_name = "http/status"
-
-[inputs.http.status_api.basic_auth]
-username = "bridge"
-password = "${HTTP_PASSWORD}"
-
+method = "HEAD"
 labels = [
   { header = "etag", label = "etag" },
   { static = { source = "status_api" } }
 ]
+
+[inputs.http.status_api.basic_auth]
+username = "bridge"
+password = "${HTTP_PASSWORD}"
 ```
 
 ## Runtime Notes
 
 - Each successful poll produces one record.
-- Requests use the GET method.
+- Requests support `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`.
+- If `method` is omitted, `GET` is used.
 - Non-JSON responses are stored as raw response bytes.
 - JSON field labels are applied only when the response body can be parsed as JSON.
 - Failed requests and non-success HTTP statuses skip that polling cycle.

--- a/src/input/http/README.md
+++ b/src/input/http/README.md
@@ -17,9 +17,6 @@ url = "https://example.com/api/metrics"
 # Must be > 0.
 repeat_interval = 10
 
-# Optional: request method (default = "GET").
-method = "GET"
-
 # Required: target entry name in remote bucket.
 entry_name = "http/metrics"
 
@@ -55,7 +52,6 @@ labels = [
 [inputs.http.status_api]
 url = "https://example.com/api/status"
 repeat_interval = 30
-method = "GET"
 entry_name = "http/status"
 
 [inputs.http.status_api.basic_auth]
@@ -71,6 +67,7 @@ labels = [
 ## Runtime Notes
 
 - Each successful poll produces one record.
+- Requests use the GET method.
 - Non-JSON responses are stored as raw response bytes.
 - JSON field labels are applied only when the response body can be parsed as JSON.
 - Failed requests and non-success HTTP statuses skip that polling cycle.

--- a/src/input/http/README.md
+++ b/src/input/http/README.md
@@ -20,9 +20,6 @@ repeat_interval = 10
 # Required: target entry name in remote bucket.
 entry_name = "http/metrics"
 
-# Optional HTTP method (default: GET).
-method = "GET"
-
 # Optional content type override for produced records.
 # If omitted, the response Content-Type header is used when available.
 content_type = "application/json"
@@ -56,7 +53,6 @@ labels = [
 url = "https://example.com/api/status"
 repeat_interval = 30
 entry_name = "http/status"
-method = "HEAD"
 labels = [
   { header = "etag", label = "etag" },
   { static = { source = "status_api" } }
@@ -70,8 +66,7 @@ password = "${HTTP_PASSWORD}"
 ## Runtime Notes
 
 - Each successful poll produces one record.
-- Requests support `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`.
-- If `method` is omitted, `GET` is used.
+- Requests use `GET`.
 - Non-JSON responses are stored as raw response bytes.
 - JSON field labels are applied only when the response body can be parsed as JSON.
 - Failed requests and non-success HTTP statuses skip that polling cycle.

--- a/src/input/http/mod.rs
+++ b/src/input/http/mod.rs
@@ -12,20 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::formats::json::{extract_json_path, value_to_label};
 use crate::input::InputLauncher;
-use crate::message::Message;
+use crate::message::{Message, Record};
 use crate::runtime::ComponentRuntime;
 use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
+use log::{debug, info, warn};
+use reqwest::header::{CONTENT_TYPE, HeaderMap};
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashMap;
-use tokio::sync::mpsc::Sender;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc::{Sender, channel};
+use tokio::time::{Duration, interval};
+
+const CHANNEL_SIZE: usize = 1024;
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct HttpConfig {
     pub url: String,
     pub repeat_interval: u64,
     pub entry_name: String,
+    #[serde(default)]
+    pub method: HttpMethod,
     #[serde(default)]
     pub content_type: Option<String>,
     #[serde(default)]
@@ -37,6 +48,7 @@ pub struct HttpConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct HttpBasicAuthConfig {
     pub username: String,
     pub password: String,
@@ -50,6 +62,33 @@ pub enum HttpLabelRule {
     Static { r#static: HashMap<String, String> },
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    #[default]
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    fn as_reqwest_method(self) -> reqwest::Method {
+        match self {
+            Self::Get => reqwest::Method::GET,
+            Self::Post => reqwest::Method::POST,
+            Self::Put => reqwest::Method::PUT,
+            Self::Patch => reqwest::Method::PATCH,
+            Self::Delete => reqwest::Method::DELETE,
+            Self::Head => reqwest::Method::HEAD,
+            Self::Options => reqwest::Method::OPTIONS,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct HttpInstance {
     pub cfg: HttpConfig,
@@ -59,7 +98,8 @@ impl HttpInstance {
     pub fn new(cfg: HttpConfig) -> Self {
         Self { cfg }
     }
-    fn validate_config(cfg: &HttpConfig) -> Result<(), Error> {
+
+    fn validate_config(cfg: &HttpConfig) -> Result<()> {
         if cfg.url.trim().is_empty() {
             bail!("HTTP input URL must not be empty");
         }
@@ -74,21 +114,160 @@ impl HttpInstance {
         if cfg.entry_name.trim().is_empty() {
             bail!("HTTP input entry_name must not be empty");
         }
+        if cfg
+            .content_type
+            .as_ref()
+            .is_some_and(|content_type| content_type.trim().is_empty())
+        {
+            bail!("HTTP input content_type must not be empty");
+        }
         if cfg.bearer_token.is_some() && cfg.basic_auth.is_some() {
             bail!("HTTP input supports only one authentication method per input");
         }
+        if let Some(auth) = &cfg.basic_auth {
+            if auth.username.trim().is_empty() {
+                bail!("HTTP input basic_auth.username must not be empty");
+            }
+            if auth.password.trim().is_empty() {
+                bail!("HTTP input basic_auth.password must not be empty");
+            }
+        }
         Ok(())
+    }
+
+    fn build_labels(
+        rules: &[HttpLabelRule],
+        headers: &HeaderMap,
+        json_body: Option<&Value>,
+    ) -> HashMap<String, String> {
+        let mut labels = HashMap::new();
+
+        for rule in rules {
+            match rule {
+                HttpLabelRule::Field { field, label } => {
+                    if let Some(value) = json_body.and_then(|body| extract_json_path(body, field)) {
+                        labels.insert(label.clone(), value_to_label(value));
+                    }
+                }
+                HttpLabelRule::Header { header, label } => {
+                    if let Some(value) = headers
+                        .get(header)
+                        .and_then(|value| value.to_str().ok())
+                        .map(str::to_string)
+                    {
+                        labels.insert(label.clone(), value);
+                    }
+                }
+                HttpLabelRule::Static { r#static } => {
+                    labels.extend(r#static.clone());
+                }
+            }
+        }
+
+        labels
+    }
+
+    fn resolved_content_type(cfg: &HttpConfig, headers: &HeaderMap) -> Option<String> {
+        cfg.content_type.clone().or_else(|| {
+            headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string)
+        })
+    }
+
+    async fn poll_once(client: &reqwest::Client, cfg: &HttpConfig) -> Result<Record> {
+        let response = build_request(client, cfg)
+            .send()
+            .await
+            .map_err(|err| anyhow::anyhow!("HTTP request to '{}' failed: {}", cfg.url, err))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            bail!("HTTP request to '{}' returned status {}", cfg.url, status);
+        }
+
+        let headers = response.headers().clone();
+        let content = response
+            .bytes()
+            .await
+            .map_err(|err| anyhow::anyhow!("Failed to read HTTP response body: {}", err))?;
+        let json_body = serde_json::from_slice::<Value>(&content).ok();
+        let timestamp_us = current_timestamp_us();
+
+        Ok(Record {
+            timestamp_us,
+            entry_name: cfg.entry_name.clone(),
+            content,
+            content_type: Self::resolved_content_type(cfg, &headers),
+            labels: Self::build_labels(&cfg.labels, &headers, json_body.as_ref()),
+        })
     }
 }
 
 #[async_trait]
 impl InputLauncher for HttpInstance {
-    async fn launch(&self, _pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
-        Self::validate_config(&self.cfg)?;
+    async fn launch(&self, pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
+        let cfg = self.cfg.clone();
+        Self::validate_config(&cfg)?;
+
         let client = create_client()?;
-        let _request = build_get_request(&client, &self.cfg);
-        bail!("HTTP input is not implemented yet")
+
+        info!(
+            "Launching HTTP input {} {} every {}s for entry '{}'",
+            cfg.method.as_reqwest_method(),
+            cfg.url,
+            cfg.repeat_interval,
+            cfg.entry_name
+        );
+
+        let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
+        let task = tokio::spawn(async move {
+            debug!("HTTP worker task started");
+            let mut ticker = interval(Duration::from_secs(cfg.repeat_interval));
+
+            loop {
+                tokio::select! {
+                    maybe_message = rx.recv() => {
+                        match maybe_message {
+                            Some(Message::Stop) => {
+                                info!("Stop message received, shutting down HTTP worker");
+                                break;
+                            }
+                            Some(other) => {
+                                debug!("Ignoring unsupported control message in HTTP input: {:?}", other);
+                            }
+                            None => {
+                                info!("HTTP control channel closed, shutting down worker");
+                                break;
+                            }
+                        }
+                    }
+                    _ = ticker.tick() => {
+                        match Self::poll_once(&client, &cfg).await {
+                            Ok(record) => {
+                                if let Err(err) = pipeline_tx.send(Message::Data(record)).await {
+                                    warn!("Failed to forward HTTP record to pipeline: {}", err);
+                                }
+                            }
+                            Err(err) => {
+                                warn!("HTTP poll failed for '{}': {}", cfg.url, err);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(ComponentRuntime { tx, task })
     }
+}
+
+fn current_timestamp_us() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
 }
 
 fn create_client() -> Result<reqwest::Client> {
@@ -97,8 +276,8 @@ fn create_client() -> Result<reqwest::Client> {
         .map_err(|err| anyhow::anyhow!("Failed to build HTTP client: {}", err))
 }
 
-fn build_get_request(client: &reqwest::Client, cfg: &HttpConfig) -> reqwest::RequestBuilder {
-    let request = client.get(&cfg.url);
+fn build_request(client: &reqwest::Client, cfg: &HttpConfig) -> reqwest::RequestBuilder {
+    let request = client.request(cfg.method.as_reqwest_method(), &cfg.url);
 
     if let Some(token) = &cfg.bearer_token {
         request.bearer_auth(token)
@@ -106,5 +285,277 @@ fn build_get_request(client: &reqwest::Client, cfg: &HttpConfig) -> reqwest::Req
         request.basic_auth(&auth.username, Some(&auth.password))
     } else {
         request
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        HttpConfig, HttpInstance, HttpLabelRule, HttpMethod, build_request, create_client,
+    };
+    use crate::input::InputLauncher;
+    use crate::message::Message;
+    use reqwest::header::{CONTENT_TYPE, ETAG, HeaderMap, HeaderValue};
+    use rstest::{fixture, rstest};
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread::JoinHandle;
+    use tokio::sync::mpsc::channel;
+    use tokio::time::{Duration, timeout};
+
+    struct TestServer {
+        address: String,
+        handle: JoinHandle<()>,
+    }
+
+    impl TestServer {
+        fn join(self) {
+            self.handle.join().unwrap();
+        }
+    }
+
+    #[fixture]
+    fn http_cfg() -> HttpConfig {
+        HttpConfig {
+            url: "https://example.com/data".to_string(),
+            repeat_interval: 5,
+            entry_name: "http/data".to_string(),
+            method: HttpMethod::Get,
+            content_type: None,
+            bearer_token: None,
+            basic_auth: None,
+            labels: Vec::new(),
+        }
+    }
+
+    #[fixture]
+    fn label_rules() -> Vec<HttpLabelRule> {
+        vec![
+            HttpLabelRule::Static {
+                r#static: HashMap::from([("source".to_string(), "http".to_string())]),
+            },
+            HttpLabelRule::Field {
+                field: "device.id".to_string(),
+                label: "device".to_string(),
+            },
+            HttpLabelRule::Header {
+                header: "etag".to_string(),
+                label: "revision".to_string(),
+            },
+        ]
+    }
+
+    fn spawn_server<F>(handler: F) -> TestServer
+    where
+        F: FnOnce(String) -> String + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap().to_string();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 2048];
+            let bytes_read = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..bytes_read]).to_string();
+            let response = handler(request);
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        TestServer { address, handle }
+    }
+
+    #[rstest]
+    fn parses_defaults_for_http_config(http_cfg: HttpConfig) {
+        let cfg = http_cfg;
+
+        assert_eq!(cfg.url, "https://example.com/data");
+        assert_eq!(cfg.repeat_interval, 5);
+        assert_eq!(cfg.entry_name, "http/data");
+        assert!(matches!(cfg.method, HttpMethod::Get));
+        assert!(cfg.content_type.is_none());
+        assert!(cfg.labels.is_empty());
+    }
+
+    #[rstest]
+    fn applies_json_header_and_static_labels(label_rules: Vec<HttpLabelRule>) {
+        let rules = label_rules;
+        let mut headers = HeaderMap::new();
+        headers.insert(ETAG, HeaderValue::from_static("abc-123"));
+        let json = json!({
+            "device": {
+                "id": 7
+            }
+        });
+
+        let labels = HttpInstance::build_labels(&rules, &headers, Some(&json));
+
+        assert_eq!(labels.get("source"), Some(&"http".to_string()));
+        assert_eq!(labels.get("device"), Some(&"7".to_string()));
+        assert_eq!(labels.get("revision"), Some(&"abc-123".to_string()));
+    }
+
+    #[rstest]
+    fn derives_content_type_from_response_when_not_overridden(http_cfg: HttpConfig) {
+        let cfg = http_cfg;
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let content_type = HttpInstance::resolved_content_type(&cfg, &headers);
+
+        assert_eq!(content_type, Some("application/json".to_string()));
+    }
+
+    #[rstest]
+    #[case(HttpMethod::Head, reqwest::Method::HEAD)]
+    #[case(HttpMethod::Delete, reqwest::Method::DELETE)]
+    fn builds_request_with_method_and_auth(
+        mut http_cfg: HttpConfig,
+        #[case] method: HttpMethod,
+        #[case] expected_method: reqwest::Method,
+    ) {
+        http_cfg.url = "https://example.com/status".to_string();
+        http_cfg.entry_name = "http/status".to_string();
+        http_cfg.method = method;
+        http_cfg.bearer_token = Some("secret".to_string());
+
+        let client = create_client().unwrap();
+        let request = build_request(&client, &http_cfg).build().unwrap();
+
+        assert_eq!(request.method(), expected_method);
+        assert_eq!(
+            request
+                .headers()
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer secret")
+        );
+    }
+
+    #[rstest]
+    #[case(
+        "ftp://example.com/data",
+        1,
+        "http/data",
+        "URL scheme must be http or https"
+    )]
+    #[case(
+        "http://example.com/data",
+        0,
+        "http/data",
+        "repeat_interval must be greater than 0"
+    )]
+    #[case("http://example.com/data", 1, "", "entry_name must not be empty")]
+    #[case(
+        "http://example.com/data",
+        1,
+        "http/data",
+        "supports only one authentication method per input"
+    )]
+    #[tokio::test]
+    async fn rejects_invalid_http_config(
+        mut http_cfg: HttpConfig,
+        #[case] url: &str,
+        #[case] repeat_interval: u64,
+        #[case] entry_name: &str,
+        #[case] expected_error: &str,
+    ) {
+        http_cfg.url = url.to_string();
+        http_cfg.repeat_interval = repeat_interval;
+        http_cfg.entry_name = entry_name.to_string();
+        if expected_error.contains("supports only one authentication method") {
+            http_cfg.bearer_token = Some("token".to_string());
+            http_cfg.basic_auth = Some(super::HttpBasicAuthConfig {
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            });
+        }
+        let (pipeline_tx, _pipeline_rx) = channel::<Message>(8);
+
+        let err = HttpInstance::new(http_cfg)
+            .launch(pipeline_tx)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains(expected_error));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn launch_emits_http_record_and_stops(
+        mut http_cfg: HttpConfig,
+        label_rules: Vec<HttpLabelRule>,
+    ) {
+        let server = spawn_server(|request| {
+            assert!(request.starts_with("GET /metrics HTTP/1.1"));
+            let body = r#"{"device":{"id":"sensor-a"},"reading":42}"#;
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nETag: rev-42\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+        });
+        http_cfg.url = format!("http://{}/metrics", server.address);
+        http_cfg.repeat_interval = 1;
+        http_cfg.entry_name = "http/metrics".to_string();
+        http_cfg.labels = label_rules;
+        let (pipeline_tx, mut pipeline_rx) = channel::<Message>(8);
+
+        let runtime = HttpInstance::new(http_cfg)
+            .launch(pipeline_tx)
+            .await
+            .unwrap();
+
+        let message = timeout(Duration::from_secs(3), pipeline_rx.recv())
+            .await
+            .expect("timed out waiting for HTTP message")
+            .expect("pipeline channel closed");
+
+        match message {
+            Message::Data(record) => {
+                assert_eq!(record.entry_name, "http/metrics");
+                assert_eq!(record.content_type, Some("application/json".to_string()));
+                assert_eq!(
+                    std::str::from_utf8(&record.content).unwrap(),
+                    r#"{"device":{"id":"sensor-a"},"reading":42}"#
+                );
+                assert_eq!(record.labels.get("device"), Some(&"sensor-a".to_string()));
+                assert_eq!(record.labels.get("revision"), Some(&"rev-42".to_string()));
+                assert_eq!(record.labels.get("source"), Some(&"http".to_string()));
+            }
+            other => panic!("expected data message, got {other:?}"),
+        }
+
+        runtime.tx.send(Message::Stop).await.unwrap();
+        runtime.task.await.unwrap();
+        server.join();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn non_success_http_response_skips_cycle(mut http_cfg: HttpConfig) {
+        let server = spawn_server(|request| {
+            assert!(request.starts_with("GET /health HTTP/1.1"));
+            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .to_string()
+        });
+        http_cfg.url = format!("http://{}/health", server.address);
+        http_cfg.repeat_interval = 1;
+        http_cfg.entry_name = "http/health".to_string();
+        let (pipeline_tx, mut pipeline_rx) = channel::<Message>(8);
+
+        let runtime = HttpInstance::new(http_cfg)
+            .launch(pipeline_tx)
+            .await
+            .unwrap();
+
+        let result = timeout(Duration::from_millis(1500), pipeline_rx.recv()).await;
+        assert!(result.is_err(), "did not expect a record for 503 response");
+
+        runtime.tx.send(Message::Stop).await.unwrap();
+        runtime.task.await.unwrap();
+        server.join();
     }
 }

--- a/src/input/http/mod.rs
+++ b/src/input/http/mod.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 ReductSoftware UG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::input::InputLauncher;
+use crate::message::Message;
+use crate::runtime::ComponentRuntime;
+use anyhow::{Error, bail};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::sync::mpsc::Sender;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct HttpConfig {
+    pub url: String,
+    pub repeat_interval: u64,
+    #[serde(default = "default_method")]
+    pub method: String,
+    pub entry_name: String,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    #[serde(default)]
+    pub bearer_token: Option<String>,
+    #[serde(default)]
+    pub basic_auth: Option<HttpBasicAuthConfig>,
+    #[serde(default)]
+    pub labels: Vec<HttpLabelRule>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct HttpBasicAuthConfig {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum HttpLabelRule {
+    Field { field: String, label: String },
+    Header { header: String, label: String },
+    Static { r#static: HashMap<String, String> },
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpInstance {
+    pub cfg: HttpConfig,
+}
+
+impl HttpInstance {
+    pub fn new(cfg: HttpConfig) -> Self {
+        Self { cfg }
+    }
+}
+
+fn default_method() -> String {
+    "GET".to_string()
+}
+
+#[async_trait]
+impl InputLauncher for HttpInstance {
+    async fn launch(&self, _pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
+        bail!("HTTP input is not implemented yet")
+    }
+}

--- a/src/input/http/mod.rs
+++ b/src/input/http/mod.rs
@@ -15,7 +15,7 @@
 use crate::input::InputLauncher;
 use crate::message::Message;
 use crate::runtime::ComponentRuntime;
-use anyhow::{Error, bail};
+use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -25,8 +25,6 @@ use tokio::sync::mpsc::Sender;
 pub struct HttpConfig {
     pub url: String,
     pub repeat_interval: u64,
-    #[serde(default = "default_method")]
-    pub method: String,
     pub entry_name: String,
     #[serde(default)]
     pub content_type: Option<String>,
@@ -61,15 +59,52 @@ impl HttpInstance {
     pub fn new(cfg: HttpConfig) -> Self {
         Self { cfg }
     }
-}
-
-fn default_method() -> String {
-    "GET".to_string()
+    fn validate_config(cfg: &HttpConfig) -> Result<(), Error> {
+        if cfg.url.trim().is_empty() {
+            bail!("HTTP input URL must not be empty");
+        }
+        let url = url::Url::parse(&cfg.url)
+            .map_err(|err| anyhow::anyhow!("Invalid HTTP input URL '{}': {}", cfg.url, err))?;
+        if !matches!(url.scheme(), "http" | "https") {
+            bail!("HTTP input URL scheme must be http or https");
+        }
+        if cfg.repeat_interval == 0 {
+            bail!("HTTP input repeat_interval must be greater than 0 seconds");
+        }
+        if cfg.entry_name.trim().is_empty() {
+            bail!("HTTP input entry_name must not be empty");
+        }
+        if cfg.bearer_token.is_some() && cfg.basic_auth.is_some() {
+            bail!("HTTP input supports only one authentication method per input");
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl InputLauncher for HttpInstance {
     async fn launch(&self, _pipeline_tx: Sender<Message>) -> Result<ComponentRuntime, Error> {
+        Self::validate_config(&self.cfg)?;
+        let client = create_client()?;
+        let _request = build_get_request(&client, &self.cfg);
         bail!("HTTP input is not implemented yet")
+    }
+}
+
+fn create_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .build()
+        .map_err(|err| anyhow::anyhow!("Failed to build HTTP client: {}", err))
+}
+
+fn build_get_request(client: &reqwest::Client, cfg: &HttpConfig) -> reqwest::RequestBuilder {
+    let request = client.get(&cfg.url);
+
+    if let Some(token) = &cfg.bearer_token {
+        request.bearer_auth(token)
+    } else if let Some(auth) = &cfg.basic_auth {
+        request.basic_auth(&auth.username, Some(&auth.password))
+    } else {
+        request
     }
 }

--- a/src/input/http/mod.rs
+++ b/src/input/http/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::formats::json::{extract_json_path, value_to_label};
+use crate::formats::{DecodeFormat, FormatHandler, PayloadFormatHandler};
 use crate::input::InputLauncher;
 use crate::message::{Message, Record};
 use crate::runtime::ComponentRuntime;
@@ -35,8 +35,6 @@ pub struct HttpConfig {
     pub url: String,
     pub repeat_interval: u64,
     pub entry_name: String,
-    #[serde(default)]
-    pub method: HttpMethod,
     #[serde(default)]
     pub content_type: Option<String>,
     #[serde(default)]
@@ -62,33 +60,6 @@ pub enum HttpLabelRule {
     Static { r#static: HashMap<String, String> },
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, Default)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HttpMethod {
-    #[default]
-    Get,
-    Post,
-    Put,
-    Patch,
-    Delete,
-    Head,
-    Options,
-}
-
-impl HttpMethod {
-    fn as_reqwest_method(self) -> reqwest::Method {
-        match self {
-            Self::Get => reqwest::Method::GET,
-            Self::Post => reqwest::Method::POST,
-            Self::Put => reqwest::Method::PUT,
-            Self::Patch => reqwest::Method::PATCH,
-            Self::Delete => reqwest::Method::DELETE,
-            Self::Head => reqwest::Method::HEAD,
-            Self::Options => reqwest::Method::OPTIONS,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct HttpInstance {
     pub cfg: HttpConfig,
@@ -97,6 +68,12 @@ pub struct HttpInstance {
 impl HttpInstance {
     pub fn new(cfg: HttpConfig) -> Self {
         Self { cfg }
+    }
+
+    fn needs_body_decode(rules: &[HttpLabelRule]) -> bool {
+        rules
+            .iter()
+            .any(|rule| matches!(rule, HttpLabelRule::Field { .. }))
     }
 
     fn validate_config(cfg: &HttpConfig) -> Result<()> {
@@ -138,15 +115,16 @@ impl HttpInstance {
     fn build_labels(
         rules: &[HttpLabelRule],
         headers: &HeaderMap,
-        json_body: Option<&Value>,
+        decoded_payload: Option<&Value>,
+        format: &dyn FormatHandler,
     ) -> HashMap<String, String> {
         let mut labels = HashMap::new();
 
         for rule in rules {
             match rule {
                 HttpLabelRule::Field { field, label } => {
-                    if let Some(value) = json_body.and_then(|body| extract_json_path(body, field)) {
-                        labels.insert(label.clone(), value_to_label(value));
+                    if let Some(value) = format.extract_field_path_value(decoded_payload, field) {
+                        labels.insert(label.clone(), value);
                     }
                 }
                 HttpLabelRule::Header { header, label } => {
@@ -165,6 +143,34 @@ impl HttpInstance {
         }
 
         labels
+    }
+
+    fn label_decode_format<'a>(
+        cfg: &'a HttpConfig,
+        headers: &'a HeaderMap,
+    ) -> Option<DecodeFormat<'a>> {
+        if !Self::needs_body_decode(&cfg.labels) {
+            return None;
+        }
+
+        let content_type = Self::resolved_content_type(cfg, headers)?;
+        let media_type = content_type.split(';').next()?.trim().to_ascii_lowercase();
+
+        if media_type == "application/json" || media_type.ends_with("+json") {
+            Some(DecodeFormat::Json)
+        } else {
+            Some(DecodeFormat::Other("unsupported"))
+        }
+    }
+
+    fn decode_payload_for_labels(
+        cfg: &HttpConfig,
+        headers: &HeaderMap,
+        payload: &[u8],
+        format: &dyn FormatHandler,
+    ) -> Option<Value> {
+        let decode_format = Self::label_decode_format(cfg, headers)?;
+        format.decode_payload(payload, decode_format)
     }
 
     fn resolved_content_type(cfg: &HttpConfig, headers: &HeaderMap) -> Option<String> {
@@ -187,12 +193,13 @@ impl HttpInstance {
             bail!("HTTP request to '{}' returned status {}", cfg.url, status);
         }
 
+        let format = PayloadFormatHandler::new(None);
         let headers = response.headers().clone();
         let content = response
             .bytes()
             .await
             .map_err(|err| anyhow::anyhow!("Failed to read HTTP response body: {}", err))?;
-        let json_body = serde_json::from_slice::<Value>(&content).ok();
+        let decoded_payload = Self::decode_payload_for_labels(cfg, &headers, &content, &format);
         let timestamp_us = current_timestamp_us();
 
         Ok(Record {
@@ -200,7 +207,7 @@ impl HttpInstance {
             entry_name: cfg.entry_name.clone(),
             content,
             content_type: Self::resolved_content_type(cfg, &headers),
-            labels: Self::build_labels(&cfg.labels, &headers, json_body.as_ref()),
+            labels: Self::build_labels(&cfg.labels, &headers, decoded_payload.as_ref(), &format),
         })
     }
 }
@@ -214,11 +221,8 @@ impl InputLauncher for HttpInstance {
         let client = create_client()?;
 
         info!(
-            "Launching HTTP input {} {} every {}s for entry '{}'",
-            cfg.method.as_reqwest_method(),
-            cfg.url,
-            cfg.repeat_interval,
-            cfg.entry_name
+            "Launching HTTP input GET {} every {}s for entry '{}'",
+            cfg.url, cfg.repeat_interval, cfg.entry_name
         );
 
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
@@ -277,7 +281,7 @@ fn create_client() -> Result<reqwest::Client> {
 }
 
 fn build_request(client: &reqwest::Client, cfg: &HttpConfig) -> reqwest::RequestBuilder {
-    let request = client.request(cfg.method.as_reqwest_method(), &cfg.url);
+    let request = client.get(&cfg.url);
 
     if let Some(token) = &cfg.bearer_token {
         request.bearer_auth(token)
@@ -290,9 +294,8 @@ fn build_request(client: &reqwest::Client, cfg: &HttpConfig) -> reqwest::Request
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        HttpConfig, HttpInstance, HttpLabelRule, HttpMethod, build_request, create_client,
-    };
+    use super::{HttpConfig, HttpInstance, HttpLabelRule, build_request, create_client};
+    use crate::formats::DecodeFormat;
     use crate::input::InputLauncher;
     use crate::message::Message;
     use reqwest::header::{CONTENT_TYPE, ETAG, HeaderMap, HeaderValue};
@@ -322,7 +325,6 @@ mod tests {
             url: "https://example.com/data".to_string(),
             repeat_interval: 5,
             entry_name: "http/data".to_string(),
-            method: HttpMethod::Get,
             content_type: None,
             bearer_token: None,
             basic_auth: None,
@@ -373,7 +375,6 @@ mod tests {
         assert_eq!(cfg.url, "https://example.com/data");
         assert_eq!(cfg.repeat_interval, 5);
         assert_eq!(cfg.entry_name, "http/data");
-        assert!(matches!(cfg.method, HttpMethod::Get));
         assert!(cfg.content_type.is_none());
         assert!(cfg.labels.is_empty());
     }
@@ -389,7 +390,12 @@ mod tests {
             }
         });
 
-        let labels = HttpInstance::build_labels(&rules, &headers, Some(&json));
+        let labels = HttpInstance::build_labels(
+            &rules,
+            &headers,
+            Some(&json),
+            &crate::formats::PayloadFormatHandler::new(None),
+        );
 
         assert_eq!(labels.get("source"), Some(&"http".to_string()));
         assert_eq!(labels.get("device"), Some(&"7".to_string()));
@@ -408,22 +414,50 @@ mod tests {
     }
 
     #[rstest]
-    #[case(HttpMethod::Head, reqwest::Method::HEAD)]
-    #[case(HttpMethod::Delete, reqwest::Method::DELETE)]
-    fn builds_request_with_method_and_auth(
-        mut http_cfg: HttpConfig,
-        #[case] method: HttpMethod,
-        #[case] expected_method: reqwest::Method,
+    fn detects_json_label_decode_format(http_cfg: HttpConfig, label_rules: Vec<HttpLabelRule>) {
+        let mut cfg = http_cfg;
+        cfg.labels = label_rules;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/json; charset=utf-8"),
+        );
+
+        let decode_format = HttpInstance::label_decode_format(&cfg, &headers);
+
+        assert!(matches!(decode_format, Some(DecodeFormat::Json)));
+    }
+
+    #[rstest]
+    fn skips_body_decode_for_non_json_payloads(
+        http_cfg: HttpConfig,
+        label_rules: Vec<HttpLabelRule>,
     ) {
+        let mut cfg = http_cfg;
+        cfg.labels = label_rules;
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+
+        let decoded_payload = HttpInstance::decode_payload_for_labels(
+            &cfg,
+            &headers,
+            br#"{"device":{"id":"sensor-a"}}"#,
+            &crate::formats::PayloadFormatHandler::new(None),
+        );
+
+        assert!(decoded_payload.is_none());
+    }
+
+    #[rstest]
+    fn builds_request_with_get_and_auth(mut http_cfg: HttpConfig) {
         http_cfg.url = "https://example.com/status".to_string();
         http_cfg.entry_name = "http/status".to_string();
-        http_cfg.method = method;
         http_cfg.bearer_token = Some("secret".to_string());
 
         let client = create_client().unwrap();
         let request = build_request(&client, &http_cfg).build().unwrap();
 
-        assert_eq!(request.method(), expected_method);
+        assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
             request
                 .headers()


### PR DESCRIPTION
Closes #15

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- added a new HTTP input that polls HTTP/HTTPS endpoints on a fixed interval
- simplified the HTTP input to use GET requests only
- added optional bearer token and basic auth support
- added static, header-based, and field-based label mapping for HTTP responses
- made HTTP field label extraction use the shared format-handler path, aligned with the MQTT interface
- only decode payloads when field-based labels require it, instead of parsing every response eagerly
- added HTTP input tests and documentation
- updated feature bundles so the `iot` bundle includes HTTP alongside MQTT, shell, and metrics

### Related issues

- #15

### Does this PR introduce a breaking change?

No.

### Other information:

- verified locally with `cargo test`
- verified locally with `cargo test --features http`
- merged the latest `origin/main` into this branch and resolved the resulting conflicts
