### PR TITLE
Add automatic ReductStore bucket creation

### DIFF
--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -125,7 +125,7 @@ runs:
           source "${{ inputs.ros-setup-script }}"
           set -u
         fi
-        cargo export target/${{ inputs.target }}/tests -- test --profile ci --target ${{ inputs.target }} --bins ${{ inputs.cargo-args }}
+        cargo export target/${{ inputs.target }}/tests -- test --profile ci --target ${{ inputs.target }} --bins ${{ inputs.cargo-args }} --features ci
 
     - name: Build and export tests (Release)
       if: github.event_name != 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -30,9 +30,10 @@ runs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Run Docker-backed ReductStore test (CI feature)
+    - name: Run ReductStore integration test (CI feature)
       shell: bash
       env:
+        REDUCTSTORE_URL: http://127.0.0.1:8383
         CARGO_TERM_COLOR: always
         RUST_LOG: debug
       run: |
@@ -42,11 +43,12 @@ runs:
           source "${{ inputs.ros-setup-script }}"
           set -u
         fi
-        cargo test ${{ inputs.cargo-args }} docker_reductstore_roundtrip_data_and_attachment -- --nocapture
+        cargo test ${{ inputs.cargo-args }} ci_reductstore_roundtrip_data_and_attachment -- --nocapture
 
     - name: Run code coverage
       shell: bash
       env:
+        REDUCTSTORE_URL: http://127.0.0.1:8383
         CARGO_TERM_COLOR: always
         RUST_LOG: debug
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
         with:
           name: ${{ matrix.artifact_prefix }}-tests-x86_64-unknown-linux-gnu
           path: ./tmp/tests
+      - uses: ./.github/actions/run-reductstore
+        with:
+          container_name: reduct-store-unit-${{ matrix.artifact_prefix }}
       - uses: ./.github/actions/unit-tests
         with:
           os: ${{ matrix.os }}
@@ -268,6 +271,9 @@ jobs:
           required-ros-distributions: jazzy
       - name: Install ROS2 interface packages
         run: sudo apt-get update && sudo apt-get install -y ros-jazzy-example-interfaces ros-jazzy-test-msgs
+      - uses: ./.github/actions/run-reductstore
+        with:
+          container_name: reduct-store-coverage
 
       - uses: ./.github/actions/coverage
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional ReductStore bucket creation with quota settings via `[remotes.reduct.create_bucket]`.
+
 ## 0.2.0 - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optional ReductStore bucket creation with quota settings via `[remotes.reduct.create_bucket]`, including human-readable `quota_size` values like `"1GB"`.
+- Optional ReductStore bucket creation via `[remotes.reduct.create_bucket]`, with configurable `quota_type`, numeric or human-readable `quota_size` values such as `"1GB"` and `"4GiB"`, updated examples/docs, and parsing coverage for valid and invalid unit strings, [PR-34](https://github.com/reductstore/reduct-bridge/pull/34).
 
 ## 0.2.0 - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optional ReductStore bucket creation with quota settings via `[remotes.reduct.create_bucket]`.
+- Optional ReductStore bucket creation with quota settings via `[remotes.reduct.create_bucket]`, including human-readable `quota_size` values like `"1GB"`.
 
 ## 0.2.0 - 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +1994,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "bytesize 2.3.1",
  "env_logger",
  "futures-util",
  "log",
@@ -2710,7 +2720,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e89b75de097d0c52a1dc2114e19439d55f0e2e42d32168c6df44f139dfb66f"
 dependencies = [
- "bytesize",
+ "bytesize 1.3.3",
  "lazy_static",
  "libc",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1.89"
 toml = "1.0.3"
 serde = { version = "1.0.228", features = ["derive"] }
 bytes = "1.11.1"
-reduct-rs = {  version = "1.19.1" }
+reduct-rs = { version = "1.19.1" }
 anyhow = "1.0.102"
 log = "0.4.28"
 env_logger = "0.11.8"
@@ -41,6 +41,7 @@ ros2_message = { git = "https://github.com/reductstore/ros2_message", optional =
 systemstat = { version = "0.2.6", optional = true }
 rumqttc = { version = "0.25.1", optional = true }
 rustls = { version = "0.23.37", optional = true, features = ["ring"] }
+bytesize = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -10,6 +10,11 @@ token_api = "***"
 bucket = "my-bucket"
 # Required key prefix inside the bucket.
 prefix = ""
+# Optional: create the bucket on startup if it does not exist.
+# Omit this table to require the bucket to exist before starting reduct-bridge.
+# [remotes.reduct.create_bucket]
+# quota_type = "FIFO" # NONE, FIFO, or HARD
+# quota_size = 1073741824 # bytes
 
 # Metrics input configuration.
 # Structure: [inputs.metrics.<input_name>]

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -14,7 +14,7 @@ prefix = ""
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB"
+# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 # Metrics input configuration.
 # Structure: [inputs.metrics.<input_name>]

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -14,7 +14,7 @@ prefix = ""
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = 1073741824 # bytes
+# quota_size = "1GB"
 
 # Metrics input configuration.
 # Structure: [inputs.metrics.<input_name>]

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -10,6 +10,11 @@ token_api = "***"
 bucket = "my-bucket"
 # Required key prefix inside the bucket.
 prefix = ""
+# Optional: create the bucket on startup if it does not exist.
+# Omit this table to require the bucket to exist before starting reduct-bridge.
+# [remotes.reduct.create_bucket]
+# quota_type = "FIFO" # NONE, FIFO, or HARD
+# quota_size = 1073741824 # bytes
 
 
 # MQTT v5 input configuration.

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -14,7 +14,7 @@ prefix = ""
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB"
+# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 
 # MQTT v5 input configuration.

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -14,7 +14,7 @@ prefix = ""
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = 1073741824 # bytes
+# quota_size = "1GB"
 
 
 # MQTT v5 input configuration.

--- a/examples/ros_config.toml
+++ b/examples/ros_config.toml
@@ -21,7 +21,7 @@ batch_max_interval_ms = 1000
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB"
+# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 
 # ROS1 input configuration.

--- a/examples/ros_config.toml
+++ b/examples/ros_config.toml
@@ -17,6 +17,11 @@ batch_max_records = 80
 batch_max_size_bytes = 8388608
 # Optional: periodic flush interval in milliseconds (default: 1000, must be > 0).
 batch_max_interval_ms = 1000
+# Optional: create the bucket on startup if it does not exist.
+# Omit this table to require the bucket to exist before starting reduct-bridge.
+# [remotes.reduct.create_bucket]
+# quota_type = "FIFO" # NONE, FIFO, or HARD
+# quota_size = 1073741824 # bytes
 
 
 # ROS1 input configuration.

--- a/examples/ros_config.toml
+++ b/examples/ros_config.toml
@@ -21,7 +21,7 @@ batch_max_interval_ms = 1000
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = 1073741824 # bytes
+# quota_size = "1GB"
 
 
 # ROS1 input configuration.

--- a/src/remote/reduct/README.md
+++ b/src/remote/reduct/README.md
@@ -41,6 +41,9 @@ batch_max_interval_ms = 1000
 quota_type = "FIFO"
 
 # Required when create_bucket is configured: quota size as bytes or a unit string.
+# Accepted examples: 1073741824, "1GB", "512MB", "4GiB", "1.5TiB", "500 B".
+# Accepted decimal units: B, K/KB, M/MB, G/GB, T/TB, P/PB, E/EB.
+# Accepted binary units: Ki/KiB, Mi/MiB, Gi/GiB, Ti/TiB, Pi/PiB, Ei/EiB.
 quota_size = "1GB"
 ```
 

--- a/src/remote/reduct/README.md
+++ b/src/remote/reduct/README.md
@@ -40,8 +40,8 @@ batch_max_interval_ms = 1000
 # Required when create_bucket is configured: NONE, FIFO, or HARD.
 quota_type = "FIFO"
 
-# Required when create_bucket is configured: quota size in bytes.
-quota_size = 1073741824
+# Required when create_bucket is configured: quota size as bytes or a unit string.
+quota_size = "1GB"
 ```
 
 ## Runtime Notes

--- a/src/remote/reduct/README.md
+++ b/src/remote/reduct/README.md
@@ -33,12 +33,23 @@ batch_max_size_bytes = 8388608
 
 # Periodic flush interval in milliseconds (default: 1000, must be > 0).
 batch_max_interval_ms = 1000
+
+# Optional: create the bucket on startup if it does not exist.
+# Omit this table to require the bucket to exist before starting reduct-bridge.
+[remotes.reduct.create_bucket]
+# Required when create_bucket is configured: NONE, FIFO, or HARD.
+quota_type = "FIFO"
+
+# Required when create_bucket is configured: quota size in bytes.
+quota_size = 1073741824
 ```
 
 ## Runtime Notes
 
 - Records are buffered and flushed by count, size, or interval.
 - Invalid batching values (`0`) are not allowed.
+- Buckets are not created automatically unless `[remotes.reduct.create_bucket]` is configured.
+- Automatic bucket creation only applies when the configured bucket is missing; existing bucket settings are not changed.
 
 ## Changes
 

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #[cfg(any(feature = "ros1", feature = "ros2"))]
 use crate::message::Attachment;
 use crate::message::{Message, Record};
@@ -18,7 +19,9 @@ use crate::remote::RemoteInstanceLauncher;
 use crate::runtime::ComponentRuntime;
 use anyhow::{Error, anyhow, bail};
 use log::{debug, info, warn};
-use reduct_rs::{Bucket, RecordBuilder, ReductClient, WriteRecordBatchBuilder};
+use reduct_rs::{
+    Bucket, ErrorCode, QuotaType, RecordBuilder, ReductClient, WriteRecordBatchBuilder,
+};
 use serde::Deserialize;
 use tokio::sync::mpsc::channel;
 use tokio::time::{Duration, MissedTickBehavior, interval};
@@ -40,6 +43,15 @@ pub struct RemoteConfig {
     pub batch_max_size_bytes: usize,
     #[serde(default = "default_batch_max_interval_ms")]
     pub batch_max_interval_ms: u64,
+
+    #[serde(default)]
+    pub create_bucket: Option<CreateBucketConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateBucketConfig {
+    pub quota_type: QuotaType,
+    pub quota_size: u64,
 }
 
 pub struct ReductInstance {
@@ -61,6 +73,37 @@ fn default_batch_max_size_bytes() -> usize {
 impl ReductInstance {
     pub fn new(cfg: RemoteConfig) -> Self {
         Self { cfg }
+    }
+
+    async fn resolve_bucket(client: &ReductClient, cfg: &RemoteConfig) -> Result<Bucket, Error> {
+        match client.get_bucket(&cfg.bucket).await {
+            Ok(bucket) => Ok(bucket),
+
+            Err(err) if err.status() == ErrorCode::NotFound => {
+                let Some(create_bucket) = &cfg.create_bucket else {
+                    bail!(
+                        "Failed to access bucket '{}': bucket does not exist. Configure [remotes.reduct.create_bucket] to create it automatically.",
+                        cfg.bucket
+                    );
+                };
+
+                info!(
+                    "Bucket '{}' does not exist, creating it with quota type {:?} and quota size {} bytes",
+                    cfg.bucket, create_bucket.quota_type, create_bucket.quota_size
+                );
+
+                client
+                    .create_bucket(&cfg.bucket)
+                    .quota_type(create_bucket.quota_type.clone())
+                    .quota_size(create_bucket.quota_size)
+                    .exist_ok(true)
+                    .send()
+                    .await
+                    .map_err(|err| anyhow!("Failed to create bucket '{}': {}", cfg.bucket, err))
+            }
+
+            Err(err) => Err(anyhow!("Failed to access bucket '{}': {}", cfg.bucket, err)),
+        }
     }
 
     fn normalize_entry_path(prefix: &str, entry_name: &str) -> Option<String> {
@@ -161,18 +204,19 @@ impl RemoteInstanceLauncher for ReductInstance {
         if cfg.batch_max_interval_ms == 0 {
             bail!("Reduct remote batch_max_interval_ms must be greater than 0");
         }
+        if let Some(create_bucket) = &cfg.create_bucket {
+            if create_bucket.quota_size == 0 {
+                bail!("Reduct remote create_bucket.quota_size must be greater than 0");
+            }
+        }
 
         let client = ReductClient::builder()
             .url(&cfg.url)
             .api_token(&cfg.token_api)
             .try_build()
             .map_err(|err| anyhow!("Failed to build Reduct client for '{}': {}", cfg.url, err))?;
-        let bucket = client
-            .get_bucket(&cfg.bucket)
-            .await
-            .map_err(|err| anyhow!("Failed to access bucket '{}': {}", cfg.bucket, err))?;
-
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
+        let bucket: Bucket = Self::resolve_bucket(&client, &cfg).await?;
         info!(
             "Launching Reduct remote '{}' bucket '{}' prefix '{}' batch >{} records, >{} bytes, every {}ms",
             cfg.url,
@@ -232,17 +276,72 @@ impl RemoteInstanceLauncher for ReductInstance {
     }
 }
 
+#[cfg(test)]
+mod config_tests {
+    use super::RemoteConfig;
+    use crate::cfg::{find_named_entry, parse_entry};
+    use reduct_rs::QuotaType;
+    use toml::Value;
+
+    fn parse_reduct_remote(config_text: &str) -> RemoteConfig {
+        let config: Value = toml::from_str(config_text).expect("parse toml");
+        let (remote_type, remote_table) =
+            find_named_entry(&config, "remotes", "local").expect("find remote");
+        assert_eq!(remote_type, "reduct");
+        parse_entry(remote_table).expect("parse remote config")
+    }
+
+    #[test]
+    fn parses_create_bucket_config_from_toml() {
+        let cfg = parse_reduct_remote(
+            r#"
+[[remotes.reduct]]
+name = "local"
+url = "http://localhost:8383"
+token_api = ""
+bucket = "my-bucket"
+prefix = ""
+
+[remotes.reduct.create_bucket]
+quota_type = "FIFO"
+quota_size = 1073741824
+"#,
+        );
+
+        let create_bucket = cfg.create_bucket.expect("create_bucket config");
+        assert_eq!(create_bucket.quota_type, QuotaType::FIFO);
+        assert_eq!(create_bucket.quota_size, 1073741824);
+    }
+
+    #[test]
+    fn omits_create_bucket_config_by_default() {
+        let cfg = parse_reduct_remote(
+            r#"
+[[remotes.reduct]]
+name = "local"
+url = "http://localhost:8383"
+token_api = ""
+bucket = "my-bucket"
+prefix = ""
+"#,
+        );
+
+        assert!(cfg.create_bucket.is_none());
+    }
+}
+
 #[cfg(all(test, feature = "ci"))]
 mod tests {
-    use super::{ReductInstance, RemoteConfig};
+    use super::{CreateBucketConfig, ReductInstance, RemoteConfig};
     #[cfg(any(feature = "ros1", feature = "ros2"))]
     use crate::message::Attachment;
     use crate::message::{Message, Record};
     use crate::remote::RemoteInstanceLauncher;
     use bytes::Bytes;
     use futures_util::StreamExt;
-    use reduct_rs::ReductClient;
+    use reduct_rs::{QuotaType, ReductClient};
     use rstest::{fixture, rstest};
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
     use serde_json::json;
     use std::collections::HashMap;
     use std::net::TcpListener;
@@ -293,6 +392,76 @@ mod tests {
         }
     }
 
+    async fn start_reductstore(container: &str, port: u16) -> ReductClient {
+        let start = run_command(&[
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            container,
+            "-p",
+            &format!("{port}:8383"),
+            "reduct/store:main",
+        ]);
+        assert!(
+            start.status.success(),
+            "failed to start docker: {}",
+            String::from_utf8_lossy(&start.stderr)
+        );
+
+        let url = format!("http://127.0.0.1:{port}");
+        let client = ReductClient::builder().url(&url).api_token("").build();
+        let mut alive = false;
+        for _ in 0..40 {
+            if client.alive().await.is_ok() {
+                alive = true;
+                break;
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+        assert!(alive, "ReductStore did not become alive at {url}");
+        sleep(Duration::from_secs(2)).await;
+
+        client
+    }
+
+    fn remote_config(
+        url: String,
+        bucket: String,
+        create_bucket: Option<CreateBucketConfig>,
+    ) -> RemoteConfig {
+        RemoteConfig {
+            url,
+            token_api: "".to_string(),
+            bucket,
+            prefix: "it/".to_string(),
+            batch_max_records: 10,
+            batch_max_size_bytes: 1024 * 1024,
+            batch_max_interval_ms: 50,
+            create_bucket,
+        }
+    }
+
+    async fn write_data_and_stop(remote: ReductInstance, message: Message) {
+        let runtime = remote.launch().await.expect("launch remote");
+        runtime.tx.send(message).await.expect("send data");
+        runtime.tx.send(Message::Stop).await.expect("send stop");
+        runtime.task.await.expect("join remote");
+    }
+
+    async fn assert_data_record(client: &ReductClient, bucket_name: &str) {
+        let bucket = client.get_bucket(bucket_name).await.expect("get bucket");
+        let mut query = bucket.query("it/entry").send().await.expect("query");
+        let rec = query.next().await.expect("record").expect("query result");
+        assert_eq!(rec.content_type(), "text/plain");
+        assert_eq!(rec.labels().get("l").map(String::as_str), Some("1"));
+        assert_eq!(
+            rec.bytes().await.expect("record bytes"),
+            Bytes::from("hello")
+        );
+    }
+
     #[fixture]
     fn data_message() -> Message {
         Message::Data(Record {
@@ -337,6 +506,112 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    async fn docker_reductstore_creates_missing_bucket(data_message: Message) {
+        let port = free_port();
+        let suffix = unique_suffix();
+        let container = format!("reduct-bridge-test-{suffix}");
+        let bucket_name = format!("it-{suffix}");
+        let url = format!("http://127.0.0.1:{port}");
+
+        let _guard = DockerGuard {
+            container: container.clone(),
+        };
+        let client = start_reductstore(&container, port).await;
+
+        let remote = ReductInstance::new(remote_config(
+            url,
+            bucket_name.clone(),
+            Some(CreateBucketConfig {
+                quota_type: QuotaType::FIFO,
+                quota_size: 1024 * 1024 * 1024,
+            }),
+        ));
+
+        write_data_and_stop(remote, data_message).await;
+
+        assert_data_record(&client, &bucket_name).await;
+        let settings = client
+            .get_bucket(&bucket_name)
+            .await
+            .expect("get bucket")
+            .settings()
+            .await
+            .expect("bucket settings");
+        assert_eq!(settings.quota_type, Some(QuotaType::FIFO));
+        assert_eq!(settings.quota_size, Some(1024 * 1024 * 1024));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn docker_reductstore_existing_bucket_is_not_modified(data_message: Message) {
+        let port = free_port();
+        let suffix = unique_suffix();
+        let container = format!("reduct-bridge-test-{suffix}");
+        let bucket_name = format!("it-{suffix}");
+        let url = format!("http://127.0.0.1:{port}");
+
+        let _guard = DockerGuard {
+            container: container.clone(),
+        };
+        let client = start_reductstore(&container, port).await;
+        client
+            .create_bucket(&bucket_name)
+            .quota_type(QuotaType::HARD)
+            .quota_size(2 * 1024 * 1024 * 1024)
+            .send()
+            .await
+            .expect("create bucket");
+
+        let remote = ReductInstance::new(remote_config(
+            url,
+            bucket_name.clone(),
+            Some(CreateBucketConfig {
+                quota_type: QuotaType::FIFO,
+                quota_size: 1024 * 1024 * 1024,
+            }),
+        ));
+
+        write_data_and_stop(remote, data_message).await;
+
+        assert_data_record(&client, &bucket_name).await;
+        let settings = client
+            .get_bucket(&bucket_name)
+            .await
+            .expect("get bucket")
+            .settings()
+            .await
+            .expect("bucket settings");
+        assert_eq!(settings.quota_type, Some(QuotaType::HARD));
+        assert_eq!(settings.quota_size, Some(2 * 1024 * 1024 * 1024));
+    }
+
+    #[tokio::test]
+    async fn docker_reductstore_missing_bucket_without_create_config_fails() {
+        let port = free_port();
+        let suffix = unique_suffix();
+        let container = format!("reduct-bridge-test-{suffix}");
+        let bucket_name = format!("it-{suffix}");
+        let url = format!("http://127.0.0.1:{port}");
+
+        let _guard = DockerGuard {
+            container: container.clone(),
+        };
+        let _client = start_reductstore(&container, port).await;
+
+        let remote = ReductInstance::new(remote_config(url, bucket_name, None));
+        let err = remote
+            .launch()
+            .await
+            .expect_err("missing bucket should fail without create config");
+
+        assert!(
+            err.to_string().contains("bucket does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
     #[cfg(any(feature = "ros1", feature = "ros2"))]
     async fn docker_reductstore_roundtrip_data_and_attachment(
         data_message: Message,
@@ -352,34 +627,7 @@ mod tests {
             container: container.clone(),
         };
 
-        let start = run_command(&[
-            "docker",
-            "run",
-            "-d",
-            "--rm",
-            "--name",
-            &container,
-            "-p",
-            &format!("{port}:8383"),
-            "reduct/store:main",
-        ]);
-        assert!(
-            start.status.success(),
-            "failed to start docker: {}",
-            String::from_utf8_lossy(&start.stderr)
-        );
-
-        let client = ReductClient::builder().url(&url).api_token("").build();
-        let mut alive = false;
-        for _ in 0..40 {
-            if client.alive().await.is_ok() {
-                alive = true;
-                break;
-            }
-            sleep(Duration::from_millis(250)).await;
-        }
-        assert!(alive, "ReductStore did not become alive at {url}");
-        sleep(Duration::from_secs(2)).await;
+        let client = start_reductstore(&container, port).await;
 
         client
             .create_bucket(&bucket_name)
@@ -388,15 +636,7 @@ mod tests {
             .await
             .expect("create bucket");
 
-        let remote = ReductInstance::new(RemoteConfig {
-            url: url.clone(),
-            token_api: "".to_string(),
-            bucket: bucket_name.clone(),
-            prefix: "it/".to_string(),
-            batch_max_records: 10,
-            batch_max_size_bytes: 1024 * 1024,
-            batch_max_interval_ms: 50,
-        });
+        let remote = ReductInstance::new(remote_config(url.clone(), bucket_name.clone(), None));
 
         let runtime = remote.launch().await.expect("launch remote");
         runtime.tx.send(data_message).await.expect("send data");

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -18,6 +18,7 @@ use crate::message::{Message, Record};
 use crate::remote::RemoteInstanceLauncher;
 use crate::runtime::ComponentRuntime;
 use anyhow::{Error, anyhow, bail};
+use bytesize::ByteSize;
 use log::{debug, info, warn};
 use reduct_rs::{
     Bucket, ErrorCode, QuotaType, RecordBuilder, ReductClient, WriteRecordBatchBuilder,
@@ -51,7 +52,7 @@ pub struct RemoteConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateBucketConfig {
     pub quota_type: QuotaType,
-    pub quota_size: u64,
+    pub quota_size: ByteSize,
 }
 
 pub struct ReductInstance {
@@ -95,7 +96,7 @@ impl ReductInstance {
                 client
                     .create_bucket(&cfg.bucket)
                     .quota_type(create_bucket.quota_type.clone())
-                    .quota_size(create_bucket.quota_size)
+                    .quota_size(create_bucket.quota_size.as_u64())
                     .exist_ok(true)
                     .send()
                     .await
@@ -205,7 +206,7 @@ impl RemoteInstanceLauncher for ReductInstance {
             bail!("Reduct remote batch_max_interval_ms must be greater than 0");
         }
         if let Some(create_bucket) = &cfg.create_bucket {
-            if create_bucket.quota_size == 0 {
+            if create_bucket.quota_size.as_u64() == 0 {
                 bail!("Reduct remote create_bucket.quota_size must be greater than 0");
             }
         }
@@ -280,6 +281,7 @@ impl RemoteInstanceLauncher for ReductInstance {
 mod config_tests {
     use super::RemoteConfig;
     use crate::cfg::{find_named_entry, parse_entry};
+    use bytesize::ByteSize;
     use reduct_rs::QuotaType;
     use toml::Value;
 
@@ -310,7 +312,29 @@ quota_size = 1073741824
 
         let create_bucket = cfg.create_bucket.expect("create_bucket config");
         assert_eq!(create_bucket.quota_type, QuotaType::FIFO);
-        assert_eq!(create_bucket.quota_size, 1073741824);
+        assert_eq!(create_bucket.quota_size, ByteSize(1073741824));
+    }
+
+    #[test]
+    fn parses_create_bucket_config_with_size_units_from_toml() {
+        let cfg = parse_reduct_remote(
+            r#"
+[[remotes.reduct]]
+name = "local"
+url = "http://localhost:8383"
+token_api = ""
+bucket = "my-bucket"
+prefix = ""
+
+[remotes.reduct.create_bucket]
+quota_type = "FIFO"
+quota_size = "1GB"
+"#,
+        );
+
+        let create_bucket = cfg.create_bucket.expect("create_bucket config");
+        assert_eq!(create_bucket.quota_type, QuotaType::FIFO);
+        assert_eq!(create_bucket.quota_size.as_u64(), 1_000_000_000);
     }
 
     #[test]
@@ -356,6 +380,7 @@ mod ci_tests {
     use crate::message::{Message, Record};
     use crate::remote::RemoteInstanceLauncher;
     use bytes::Bytes;
+    use bytesize::ByteSize;
     use futures_util::StreamExt;
     use reduct_rs::{QuotaType, ReductClient};
     use rstest::{fixture, rstest};
@@ -476,7 +501,7 @@ mod ci_tests {
             bucket_name.clone(),
             Some(CreateBucketConfig {
                 quota_type: QuotaType::FIFO,
-                quota_size: 1024 * 1024 * 1024,
+                quota_size: ByteSize(1024 * 1024 * 1024),
             }),
         ));
 
@@ -514,7 +539,7 @@ mod ci_tests {
             bucket_name.clone(),
             Some(CreateBucketConfig {
                 quota_type: QuotaType::FIFO,
-                quota_size: 1024 * 1024 * 1024,
+                quota_size: ByteSize(1024 * 1024 * 1024),
             }),
         ));
 

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -330,8 +330,26 @@ prefix = ""
     }
 }
 
+#[cfg(test)]
+mod unit_tests {
+    use super::ReductInstance;
+
+    #[test]
+    fn normalize_entry_path_collapses_extra_slashes() {
+        assert_eq!(
+            ReductInstance::normalize_entry_path("ros_data/", "/tf"),
+            Some("ros_data/tf".to_string())
+        );
+        assert_eq!(
+            ReductInstance::normalize_entry_path("/root//", "//a//b/"),
+            Some("root/a/b".to_string())
+        );
+        assert_eq!(ReductInstance::normalize_entry_path("/", "//"), None);
+    }
+}
+
 #[cfg(all(test, feature = "ci"))]
-mod tests {
+mod ci_tests {
     use super::{CreateBucketConfig, ReductInstance, RemoteConfig};
     #[cfg(any(feature = "ros1", feature = "ros2"))]
     use crate::message::Attachment;
@@ -344,15 +362,9 @@ mod tests {
     #[cfg(any(feature = "ros1", feature = "ros2"))]
     use serde_json::json;
     use std::collections::HashMap;
-    use std::net::TcpListener;
-    use std::process::Command;
+    use std::env;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::time::sleep;
-
-    fn free_port() -> u16 {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");
-        listener.local_addr().expect("local addr").port()
-    }
 
     fn unique_suffix() -> String {
         format!(
@@ -365,52 +377,12 @@ mod tests {
         )
     }
 
-    fn run_command(args: &[&str]) -> std::process::Output {
-        Command::new(args[0])
-            .args(&args[1..])
-            .output()
-            .expect("run command")
+    fn reductstore_url() -> String {
+        env::var("REDUCTSTORE_URL").unwrap_or_else(|_| "http://127.0.0.1:8383".to_string())
     }
 
-    struct DockerGuard {
-        container: String,
-    }
-
-    impl Drop for DockerGuard {
-        fn drop(&mut self) {
-            if std::thread::panicking() {
-                let logs = run_command(&["docker", "logs", &self.container]);
-                eprintln!("=== ReductStore logs ({}) ===", self.container);
-                if !logs.stdout.is_empty() {
-                    eprintln!("{}", String::from_utf8_lossy(&logs.stdout));
-                }
-                if !logs.stderr.is_empty() {
-                    eprintln!("{}", String::from_utf8_lossy(&logs.stderr));
-                }
-            }
-            let _ = run_command(&["docker", "rm", "-f", &self.container]);
-        }
-    }
-
-    async fn start_reductstore(container: &str, port: u16) -> ReductClient {
-        let start = run_command(&[
-            "docker",
-            "run",
-            "-d",
-            "--rm",
-            "--name",
-            container,
-            "-p",
-            &format!("{port}:8383"),
-            "reduct/store:main",
-        ]);
-        assert!(
-            start.status.success(),
-            "failed to start docker: {}",
-            String::from_utf8_lossy(&start.stderr)
-        );
-
-        let url = format!("http://127.0.0.1:{port}");
+    async fn reductstore_client() -> ReductClient {
+        let url = reductstore_url();
         let client = ReductClient::builder().url(&url).api_token("").build();
         let mut alive = false;
         for _ in 0..40 {
@@ -491,32 +463,13 @@ mod tests {
         })
     }
 
-    #[test]
-    fn normalize_entry_path_collapses_extra_slashes() {
-        assert_eq!(
-            ReductInstance::normalize_entry_path("ros_data/", "/tf"),
-            Some("ros_data/tf".to_string())
-        );
-        assert_eq!(
-            ReductInstance::normalize_entry_path("/root//", "//a//b/"),
-            Some("root/a/b".to_string())
-        );
-        assert_eq!(ReductInstance::normalize_entry_path("/", "//"), None);
-    }
-
     #[rstest]
     #[tokio::test]
-    async fn docker_reductstore_creates_missing_bucket(data_message: Message) {
-        let port = free_port();
+    async fn ci_reductstore_creates_missing_bucket(data_message: Message) {
         let suffix = unique_suffix();
-        let container = format!("reduct-bridge-test-{suffix}");
         let bucket_name = format!("it-{suffix}");
-        let url = format!("http://127.0.0.1:{port}");
-
-        let _guard = DockerGuard {
-            container: container.clone(),
-        };
-        let client = start_reductstore(&container, port).await;
+        let url = reductstore_url();
+        let client = reductstore_client().await;
 
         let remote = ReductInstance::new(remote_config(
             url,
@@ -543,17 +496,11 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn docker_reductstore_existing_bucket_is_not_modified(data_message: Message) {
-        let port = free_port();
+    async fn ci_reductstore_existing_bucket_is_not_modified(data_message: Message) {
         let suffix = unique_suffix();
-        let container = format!("reduct-bridge-test-{suffix}");
         let bucket_name = format!("it-{suffix}");
-        let url = format!("http://127.0.0.1:{port}");
-
-        let _guard = DockerGuard {
-            container: container.clone(),
-        };
-        let client = start_reductstore(&container, port).await;
+        let url = reductstore_url();
+        let client = reductstore_client().await;
         client
             .create_bucket(&bucket_name)
             .quota_type(QuotaType::HARD)
@@ -586,17 +533,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_reductstore_missing_bucket_without_create_config_fails() {
-        let port = free_port();
+    async fn ci_reductstore_missing_bucket_without_create_config_fails() {
         let suffix = unique_suffix();
-        let container = format!("reduct-bridge-test-{suffix}");
         let bucket_name = format!("it-{suffix}");
-        let url = format!("http://127.0.0.1:{port}");
-
-        let _guard = DockerGuard {
-            container: container.clone(),
-        };
-        let _client = start_reductstore(&container, port).await;
+        let url = reductstore_url();
+        let _client = reductstore_client().await;
 
         let remote = ReductInstance::new(remote_config(url, bucket_name, None));
         let err = remote
@@ -613,21 +554,14 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[cfg(any(feature = "ros1", feature = "ros2"))]
-    async fn docker_reductstore_roundtrip_data_and_attachment(
+    async fn ci_reductstore_roundtrip_data_and_attachment(
         data_message: Message,
         ros_attachment_message: Message,
     ) {
-        let port = free_port();
         let suffix = unique_suffix();
-        let container = format!("reduct-bridge-test-{suffix}");
         let bucket_name = format!("it-{suffix}");
-        let url = format!("http://127.0.0.1:{port}");
-
-        let _guard = DockerGuard {
-            container: container.clone(),
-        };
-
-        let client = start_reductstore(&container, port).await;
+        let url = reductstore_url();
+        let client = reductstore_client().await;
 
         client
             .create_bucket(&bucket_name)
@@ -636,7 +570,7 @@ mod tests {
             .await
             .expect("create bucket");
 
-        let remote = ReductInstance::new(remote_config(url.clone(), bucket_name.clone(), None));
+        let remote = ReductInstance::new(remote_config(url, bucket_name.clone(), None));
 
         let runtime = remote.launch().await.expect("launch remote");
         runtime.tx.send(data_message).await.expect("send data");

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -283,19 +283,19 @@ mod config_tests {
     use crate::cfg::{find_named_entry, parse_entry};
     use bytesize::ByteSize;
     use reduct_rs::QuotaType;
+    use rstest::rstest;
     use toml::Value;
 
-    fn parse_reduct_remote(config_text: &str) -> RemoteConfig {
+    fn parse_reduct_remote_config(config_text: &str) -> anyhow::Result<RemoteConfig> {
         let config: Value = toml::from_str(config_text).expect("parse toml");
         let (remote_type, remote_table) =
             find_named_entry(&config, "remotes", "local").expect("find remote");
         assert_eq!(remote_type, "reduct");
-        parse_entry(remote_table).expect("parse remote config")
+        parse_entry(remote_table)
     }
 
-    #[test]
-    fn parses_create_bucket_config_from_toml() {
-        let cfg = parse_reduct_remote(
+    fn build_remote_config(create_bucket: &str) -> String {
+        format!(
             r#"
 [[remotes.reduct]]
 name = "local"
@@ -303,52 +303,56 @@ url = "http://localhost:8383"
 token_api = ""
 bucket = "my-bucket"
 prefix = ""
-
-[remotes.reduct.create_bucket]
-quota_type = "FIFO"
-quota_size = 1073741824
-"#,
-        );
-
-        let create_bucket = cfg.create_bucket.expect("create_bucket config");
-        assert_eq!(create_bucket.quota_type, QuotaType::FIFO);
-        assert_eq!(create_bucket.quota_size, ByteSize(1073741824));
+{create_bucket}
+"#
+        )
     }
 
-    #[test]
-    fn parses_create_bucket_config_with_size_units_from_toml() {
-        let cfg = parse_reduct_remote(
+    #[rstest]
+    #[case("1073741824", ByteSize(1073741824))]
+    #[case("\"1GB\"", ByteSize(1_000_000_000))]
+    #[case("\"4GiB\"", ByteSize(4 * 1024 * 1024 * 1024))]
+    fn parses_create_bucket_config_from_toml(
+        #[case] quota_size: &str,
+        #[case] expected_size: ByteSize,
+    ) {
+        let cfg = parse_reduct_remote_config(&build_remote_config(&format!(
             r#"
-[[remotes.reduct]]
-name = "local"
-url = "http://localhost:8383"
-token_api = ""
-bucket = "my-bucket"
-prefix = ""
 
 [remotes.reduct.create_bucket]
 quota_type = "FIFO"
-quota_size = "1GB"
-"#,
-        );
+quota_size = {quota_size}
+"#
+        )))
+        .expect("parse remote config");
 
         let create_bucket = cfg.create_bucket.expect("create_bucket config");
         assert_eq!(create_bucket.quota_type, QuotaType::FIFO);
-        assert_eq!(create_bucket.quota_size.as_u64(), 1_000_000_000);
+        assert_eq!(create_bucket.quota_size, expected_size);
+    }
+
+    #[rstest]
+    #[case("\"10XB\"")]
+    #[case("\"abc\"")]
+    fn rejects_create_bucket_config_with_invalid_size_unit(#[case] quota_size: &str) {
+        let err = parse_reduct_remote_config(&build_remote_config(&format!(
+            r#"
+
+[remotes.reduct.create_bucket]
+quota_type = "FIFO"
+quota_size = {quota_size}
+"#
+        )))
+        .expect_err("invalid quota_size should fail");
+
+        let message = err.to_string();
+        assert!(message.contains("Failed to deserialize section entry"));
     }
 
     #[test]
     fn omits_create_bucket_config_by_default() {
-        let cfg = parse_reduct_remote(
-            r#"
-[[remotes.reduct]]
-name = "local"
-url = "http://localhost:8383"
-token_api = ""
-bucket = "my-bucket"
-prefix = ""
-"#,
-        );
+        let cfg =
+            parse_reduct_remote_config(&build_remote_config("")).expect("parse remote config");
 
         assert!(cfg.create_bucket.is_none());
     }


### PR DESCRIPTION
Closes #13

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added optional `[remotes.reduct.create_bucket]` configuration for creating missing ReductStore buckets on startup.
- Added quota type and quota size settings for automatically created buckets.
- Preserved existing behavior when auto-create is omitted: missing buckets fail with a clear error.
- Added Docker-backed ReductStore integration tests for missing bucket creation, existing bucket behavior, and disabled auto-create failure.
- Updated Reduct remote docs, example configs, and CHANGELOG.md.

### Related issues

- #13

### Does this PR introduce a breaking change?

No. Bucket creation is disabled unless `[remotes.reduct.create_bucket]` is configured.

### Other information:

Verified with:

```bash
cargo fmt --check
cargo test --no-default-features --features shell config_tests
cargo test --no-default-features --features ci --no-run
cargo test --no-default-features --features ci docker_reductstore_
cargo test --no-default-features --features shell
```