### PR TITLE
Fix Docker image runtime packaging

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -30,6 +30,14 @@ inputs:
     description: 'Upload /tmp/image.tar as artifact.'
     required: false
     default: 'true'
+  base_image:
+    description: 'Base Docker image (e.g., ubuntu:24.04, ubuntu:22.04).'
+    required: false
+    default: 'ubuntu:24.04'
+  ros_distro:
+    description: 'ROS distro to install (empty for no ROS).'
+    required: false
+    default: ''
 outputs:
   digest:
     description: 'Image digest from docker/build-push-action.'
@@ -113,6 +121,9 @@ runs:
         platforms: ${{ inputs.platform }}
         labels: ${{ inputs.docker_labels }}
         outputs: ${{ inputs.build_outputs }}
+        build-args: |
+          BASE_IMAGE=${{ inputs.base_image }}
+          ROS_DISTRO=${{ inputs.ros_distro }}
 
     - name: Upload artifact
       if: ${{ inputs.upload_artifact == 'true' }}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -38,6 +38,14 @@ inputs:
     description: 'ROS distro to install (empty for no ROS).'
     required: false
     default: ''
+  sbom:
+    description: 'Generate SBOM attestation.'
+    required: false
+    default: 'false'
+  provenance:
+    description: 'Generate provenance attestation.'
+    required: false
+    default: 'false'
 outputs:
   digest:
     description: 'Image digest from docker/build-push-action.'
@@ -124,6 +132,8 @@ runs:
         build-args: |
           BASE_IMAGE=${{ inputs.base_image }}
           ROS_DISTRO=${{ inputs.ros_distro }}
+        sbom: ${{ inputs.sbom }}
+        provenance: ${{ inputs.provenance }}
 
     - name: Upload artifact
       if: ${{ inputs.upload_artifact == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,8 @@ jobs:
           build_outputs: type=image,push=true
           base_image: ${{ matrix.base_image }}
           ros_distro: ${{ matrix.ros_distro }}
+          sbom: 'true'
+          provenance: mode=max
 
   snap_release:
     name: Build and Publish Snap Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,15 +298,23 @@ jobs:
           - image_artifact_name: image-ros1-linux-amd64
             bridge_artifact_name: bridge-ros1-x86_64-unknown-linux-gnu
             image_tag: reduct/bridge:ros1-test
+            base_image: ubuntu:24.04
+            ros_distro: ""
           - image_artifact_name: image-ros2-jazzy-linux-amd64
             bridge_artifact_name: bridge-ros2-jazzy-x86_64-unknown-linux-gnu
             image_tag: reduct/bridge:ros2-jazzy-test
+            base_image: ubuntu:24.04
+            ros_distro: jazzy
           - image_artifact_name: image-ros2-humble-linux-amd64
             bridge_artifact_name: bridge-ros2-humble-x86_64-unknown-linux-gnu
             image_tag: reduct/bridge:ros2-humble-test
+            base_image: ubuntu:22.04
+            ros_distro: humble
           - image_artifact_name: image-iot-linux-amd64
             bridge_artifact_name: bridge-iot-x86_64-unknown-linux-gnu
             image_tag: reduct/bridge:iot-test
+            base_image: ubuntu:24.04
+            ros_distro: ""
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -317,6 +325,8 @@ jobs:
           bridge_artifact_name: ${{ matrix.bridge_artifact_name }}
           image_artifact_name: ${{ matrix.image_artifact_name }}
           image_tag: ${{ matrix.image_tag }}
+          base_image: ${{ matrix.base_image }}
+          ros_distro: ${{ matrix.ros_distro }}
 
   all_tests_passed:
     name: All Tests Passed
@@ -431,21 +441,29 @@ jobs:
             bridge_artifact_name: bridge-ros1-x86_64-unknown-linux-gnu
             image_name: reduct/bridge
             image_suffix: ros1
+            base_image: ubuntu:24.04
+            ros_distro: ""
           - platform: linux/amd64
             cargo_target: x86_64-unknown-linux-gnu
             bridge_artifact_name: bridge-ros2-jazzy-x86_64-unknown-linux-gnu
             image_name: reduct/bridge
             image_suffix: ros2-jazzy
+            base_image: ubuntu:24.04
+            ros_distro: jazzy
           - platform: linux/amd64
             cargo_target: x86_64-unknown-linux-gnu
             bridge_artifact_name: bridge-ros2-humble-x86_64-unknown-linux-gnu
             image_name: reduct/bridge
             image_suffix: ros2-humble
+            base_image: ubuntu:22.04
+            ros_distro: humble
           - platform: linux/amd64
             cargo_target: x86_64-unknown-linux-gnu
             bridge_artifact_name: bridge-iot-x86_64-unknown-linux-gnu
             image_name: reduct/bridge
             image_suffix: iot
+            base_image: ubuntu:24.04
+            ros_distro: ""
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -462,7 +480,9 @@ jobs:
         with:
           images: ${{ matrix.image_name }}
           tags: |
-            type=raw,value=${{ matrix.image_suffix }}-${{ github.ref_name }}
+            type=semver,pattern=v{{version}},suffix=-${{ matrix.image_suffix }}
+            type=raw,value=main-${{ matrix.image_suffix }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest-${{ matrix.image_suffix }},enable=${{ github.ref == 'refs/heads/stable' }}
 
       - name: Build and push Docker image to GitHub repo
         id: build
@@ -471,10 +491,12 @@ jobs:
           platform: ${{ matrix.platform }}
           target: ${{ matrix.cargo_target }}
           bridge_artifact_name: ${{ matrix.bridge_artifact_name }}
-          image_tag: ${{ matrix.image_name }}
+          image_tag: ${{ steps.meta.outputs.tags }}
           docker_labels: ${{ steps.meta.outputs.labels }}
           upload_artifact: "false"
-          build_outputs: type=image,name=${{ matrix.image_name }},push=true
+          build_outputs: type=image,push=true
+          base_image: ${{ matrix.base_image }}
+          ros_distro: ${{ matrix.ros_distro }}
 
   snap_release:
     name: Build and Publish Snap Package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Docker image pipeline now builds per variant with Ubuntu base selection, non-root runtime, ROS2 runtime provisioning for ROS variants, corrected DockerHub tagging, and SBOM/provenance attestations, [PR-36](https://github.com/reductstore/reduct-bridge/pull/36)
+
 ## 0.2.0 - 2026-05-11
 
 ### Added

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -12,6 +12,11 @@ FROM ${BASE_IMAGE}
 
 ARG ROS_DISTRO=""
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN if [ -n "$ROS_DISTRO" ]; then \
         apt-get update \
         && apt-get install -y --no-install-recommends \
@@ -25,9 +30,7 @@ RUN if [ -n "$ROS_DISTRO" ]; then \
             ros-${ROS_DISTRO}-ros-core \
         && rm -rf /var/lib/apt/lists/*; \
     else \
-        apt-get update \
-        && apt-get install -y --no-install-recommends ca-certificates \
-        && rm -rf /var/lib/apt/lists/*; \
+        true; \
     fi
 
 ENV ROS_DISTRO=${ROS_DISTRO}

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -1,12 +1,53 @@
-FROM debian:bookworm-slim
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE=ubuntu:24.04
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+FROM ${BASE_IMAGE} AS builder
 
-COPY .image-build/ /
+RUN groupadd --gid 10001 reduct \
+    && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin reduct
+
+RUN mkdir -p /data && chown 10001:10001 /data
+
+FROM ${BASE_IMAGE}
+
+ARG ROS_DISTRO=""
+
+RUN if [ -n "$ROS_DISTRO" ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends \
+            curl \
+            gnupg \
+            lsb-release \
+        && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2.list \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends \
+            ros-${ROS_DISTRO}-ros-core \
+        && rm -rf /var/lib/apt/lists/*; \
+    else \
+        apt-get update \
+        && apt-get install -y --no-install-recommends ca-certificates \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+ENV ROS_DISTRO=${ROS_DISTRO}
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/shadow /etc/shadow
+COPY --from=builder /etc/gshadow /etc/gshadow
+COPY --chown=10001:10001 --from=builder /data /data
+
+COPY .image-build/usr/local/bin/reduct-bridge /usr/local/bin/reduct-bridge
+COPY .image-build/usr/local/bin/reduct-cli /usr/local/bin/reduct-cli
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 8383
+USER 10001:10001
+
 VOLUME ["/data"]
 
-ENTRYPOINT ["/usr/local/bin/reduct-bridge"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["reduct-bridge"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${ROS_DISTRO:-}" ] && [ -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]; then
+    source "/opt/ros/${ROS_DISTRO}/setup.bash"
+fi
+
+data_path="${RS_DATA_PATH:-/data}"
+
+if ! test -r "$data_path" -a -w "$data_path" -a -x "$data_path"; then
+    owner_uid="$(stat -c '%u' "$data_path" 2>/dev/null || echo 'unknown')"
+    owner_gid="$(stat -c '%g' "$data_path" 2>/dev/null || echo 'unknown')"
+    mode="$(stat -c '%a' "$data_path" 2>/dev/null || echo 'unknown')"
+    echo "Error: '$data_path' is not accessible for process UID:GID $(id -u):$(id -g)." >&2
+    echo "Folder owner UID:GID is $owner_uid:$owner_gid (mode=$mode)." >&2
+    echo "Fix options:" >&2
+    echo "  1) Change owner on the host path to $(id -u):$(id -g)" >&2
+    echo "  2) Adjust permissions on the host path (e.g.: sudo chmod -R 770 <host_data_dir>)" >&2
+    echo "  3) Run with a matching user (docker --user $owner_uid:$owner_gid ...)" >&2
+    exit 1
+fi
+
+exec "$@"


### PR DESCRIPTION
Closes #35 

## Summary
- Rework Docker image builds to use Ubuntu bases, a non-root reduct user, and an entrypoint that validates data directory access.
- Add ROS runtime installation via matrix-controlled build args so ROS 2 images include the required shared libraries.
- Fix DockerHub tagging and enable SBOM/provenance attestations for pushed images.

## Validation
- Reviewed the full diff against origin/stable.
- Verified the branch was clean before pushing.