### PR TITLE
Refactor build features into bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,28 +44,28 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
             os: ubuntu-22.04
             compiler: "gcc"
-            cargo_args: "--no-default-features --features shell,ros1"
+            cargo_args: "--no-default-features --features ros1"
             ros_distro: ""
             ros_setup_script: ""
           - artifact_prefix: "bridge-ros2-jazzy"
             target: "x86_64-unknown-linux-gnu"
             os: ubuntu-24.04
             compiler: "gcc"
-            cargo_args: "--no-default-features --features shell,ros2,metrics"
+            cargo_args: "--no-default-features --features ros2"
             ros_distro: "jazzy"
             ros_setup_script: "/opt/ros/jazzy/setup.bash"
           - artifact_prefix: "bridge-ros2-humble"
             target: "x86_64-unknown-linux-gnu"
             os: ubuntu-22.04
             compiler: "gcc"
-            cargo_args: "--no-default-features --features shell,ros2,metrics"
+            cargo_args: "--no-default-features --features ros2"
             ros_distro: "humble"
             ros_setup_script: "/opt/ros/humble/setup.bash"
           - artifact_prefix: "bridge-iot"
             target: "x86_64-unknown-linux-gnu"
             os: ubuntu-24.04
             compiler: "gcc"
-            cargo_args: "--no-default-features --features shell,metrics,iot"
+            cargo_args: "--no-default-features --features iot"
             ros_distro: ""
             ros_setup_script: ""
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Optional ReductStore bucket creation via `[remotes.reduct.create_bucket]`, with configurable `quota_type`, numeric or human-readable `quota_size` values such as `"1GB"` and `"4GiB"`, updated examples/docs, and parsing coverage for valid and invalid unit strings, [PR-34](https://github.com/reductstore/reduct-bridge/pull/34).
+- Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
+
 ## 0.2.1 - 2026-05-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2024"
 [features]
 default = ["shell"]
 all-inputs = ["shell", "ros1", "ros2", "metrics", "iot"]
-ros1 = ["dep:rosrust"]
-ros2 = ["dep:rclrs", "dep:ros2_message"]
+ros1 = ["dep:rosrust","shell", "metrics"]
+ros2 = ["dep:rclrs", "dep:ros2_message", "shell", "metrics"]
 shell = []
 metrics = ["dep:systemstat"]
 mqtt = ["dep:rumqttc", "dep:rustls", "dep:prost-reflect", "dep:prost", "dep:base64"]
-iot = ["mqtt"]
+iot = ["shell", "metrics", "mqtt"]
 ci = []
 
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,50 @@ labels = [
 
 ## Installation
 
+ReductBridge is published in build types named after Cargo feature bundles: `ros1`, `ros2`, and `iot`.
+Choose the build type for the input family you need.
+
+### Build Types
+
+Published packages and Docker images are split into these build types so each artifact only includes the dependencies needed for its input family.
+
+| Build type | Description | Included inputs | Published artifact names |
+| --- | --- | --- | --- |
+| `ros1` | ROS1 robotics bundle. | [ROS1](src/input/ros1/README.md), [Shell](src/input/shell/README.md), [Metrics](src/input/metrics/README.md) | Snap: `reduct-bridge-ros1`; Docker build type: `ros1`; binary: `bridge-ros1.x86_64-unknown-linux-gnu.tar.gz` |
+| `ros2` | ROS2 robotics bundle. | [ROS2](src/input/ros2/README.md), [Shell](src/input/shell/README.md), [Metrics](src/input/metrics/README.md) | Snap: `reduct-bridge-ros2`; Docker build types: `ros2-jazzy`, `ros2-humble`; binaries: `bridge-ros2-jazzy.x86_64-unknown-linux-gnu.tar.gz`, `bridge-ros2-humble.x86_64-unknown-linux-gnu.tar.gz` |
+| `iot` | MQTT/IIoT bundle. | [MQTT](src/input/mqtt/README.md), [Shell](src/input/shell/README.md), [Metrics](src/input/metrics/README.md) | Snap: `reduct-bridge-iot`; Docker build type: `iot`; binary: `bridge-iot.x86_64-unknown-linux-gnu.tar.gz` |
+
+Note: ROS2 binary and Docker artifacts are published per ROS distribution: `ros2-jazzy` and `ros2-humble`. The ROS2 snap is published as `reduct-bridge-ros2` and currently uses the Jazzy build.
+
+Input names in configuration use their input table names, for example `[inputs.ros.*]`, `[inputs.ros2.*]`, `[inputs.mqtt.*]`, `[inputs.shell.*]`, and `[inputs.metrics.*]`.
+
+### Docker
+
+Docker images are published as `reduct/bridge:<tag>`, where `<tag>` combines a release channel or version with the build type.
+For ROS2 Docker images, use the ROS distribution-specific build type: `ros2-jazzy` or `ros2-humble`.
+
+```bash
+docker pull reduct/bridge:main-<build-type>      # development builds from main
+docker pull reduct/bridge:latest-<build-type>    # stable builds
+docker pull reduct/bridge:v<version>-<build-type> # release builds
+```
+
+For example:
+
+```bash
+docker pull reduct/bridge:main-iot
+docker pull reduct/bridge:main-ros2-jazzy
+docker pull reduct/bridge:main-ros2-humble
+```
+
+Run the container with a mounted config file:
+
+```bash
+docker run --rm \
+  -v "$PWD/config.toml:/etc/reduct-bridge/config.toml:ro" \
+  reduct/bridge:main-iot /etc/reduct-bridge/config.toml
+```
+
 ### Snap (Ubuntu 22.04+)
 
 ```bash
@@ -104,8 +148,8 @@ To build additional inputs explicitly from source:
 
 ```bash
 cargo build --no-default-features --features ros1
-cargo build --no-default-features --features shell,metrics,iot
-cargo build --no-default-features --features all-inputs
+cargo build --no-default-features --features ros2
+cargo build --no-default-features --features iot
 ```
 
 ## Usage

--- a/src/input/metrics/README.md
+++ b/src/input/metrics/README.md
@@ -94,12 +94,6 @@ Build only metrics input support:
 cargo build --no-default-features --features metrics
 ```
 
-Build all inputs in one command:
-
-```bash
-cargo build --no-default-features --features all-inputs
-```
-
 ## Runtime Notes
 
 - If `metrics` is empty or omitted, the input collects all supported metrics.

--- a/src/input/ros1/README.md
+++ b/src/input/ros1/README.md
@@ -53,12 +53,6 @@ Build only ROS1 input support:
 cargo build --no-default-features --features ros1
 ```
 
-Build all inputs in one command:
-
-```bash
-cargo build --no-default-features --features all-inputs
-```
-
 ## Runtime Notes
 
 - Empty topic names are not allowed.

--- a/src/input/ros2/README.md
+++ b/src/input/ros2/README.md
@@ -66,13 +66,6 @@ cargo build --no-default-features --features ros2
 
 The ROS2 installation must include the standard interface packages that `rclrs` links against. In CI we install `ros-jazzy-example-interfaces` and `ros-jazzy-test-msgs` explicitly.
 
-Build all inputs in one command:
-
-```bash
-source /opt/ros/jazzy/setup.bash
-cargo build --no-default-features --features all-inputs
-```
-
 ## Runtime Notes
 
 - Empty topic names are not allowed.


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update, CI maintenance

### What was changed?

- Treat `ros1`, `ros2`, and `iot` as bundle-style Cargo features and update CI builds to use those bundle features directly.
- Document build types, included inputs, published artifact names, and Docker installation tags.
- Remove obsolete `all-inputs` source-build examples from input documentation.

### Related issues



### Does this PR introduce a breaking change?

No.

### Other information:

Validated bundle feature selection with `cargo metadata --no-deps --format-version 1 --no-default-features --features ros1`, `ros2`, and `iot`.
