### PR TITLE
feat: support preferred keyed syntax for reduct remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTP input for polling HTTP/HTTPS endpoints on a fixed interval with GET requests, optional bearer/basic auth, header/static/JSON field label mapping, and HTTP-specific tests and documentation, [PR-33](https://github.com/reductstore/reduct-bridge/pull/33).
 - Optional ReductStore bucket creation via `[remotes.reduct.create_bucket]`, with configurable `quota_type`, numeric or human-readable `quota_size` values such as `"1GB"` and `"4GiB"`, updated examples/docs, and parsing coverage for valid and invalid unit strings, [PR-34](https://github.com/reductstore/reduct-bridge/pull/34).
 - Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
+- Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
 
 ## 0.2.1 - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTP input for polling HTTP/HTTPS endpoints on a fixed interval with GET requests, optional bearer/basic auth, header/static/JSON field label mapping, and HTTP-specific tests and documentation, [PR-33](https://github.com/reductstore/reduct-bridge/pull/33).
 - Optional ReductStore bucket creation via `[remotes.reduct.create_bucket]`, with configurable `quota_type`, numeric or human-readable `quota_size` values such as `"1GB"` and `"4GiB"`, updated examples/docs, and parsing coverage for valid and invalid unit strings, [PR-34](https://github.com/reductstore/reduct-bridge/pull/34).
 - Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
-- Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
+- Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, now with deprecation warnings when the legacy array syntax is used, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
 
 ## 0.2.1 - 2026-05-19
 

--- a/examples/http_config.toml
+++ b/examples/http_config.toml
@@ -1,7 +1,7 @@
 # ReductStore remote destination.
-[[remotes.reduct]]
+[remotes.reduct.local]
 # Unique remote name referenced by pipelines.<name>.remote.
-name = "local"
+
 # ReductStore base URL.
 url = "http://localhost:8383"
 # API token used for authentication.
@@ -12,7 +12,7 @@ bucket = "my-bucket"
 prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
-# [remotes.reduct.create_bucket]
+# [remotes.reduct.local.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
 # quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -1,7 +1,7 @@
 # ReductStore remote destination.
-[[remotes.reduct]]
+[remotes.reduct.local]
 # Unique remote name referenced by pipelines.<name>.remote.
-name = "local"
+
 # ReductStore base URL.
 url = "http://localhost:8383"
 # API token used for authentication.
@@ -12,7 +12,7 @@ bucket = "my-bucket"
 prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
-# [remotes.reduct.create_bucket]
+# [remotes.reduct.local.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
 # quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -1,7 +1,7 @@
 # ReductStore remote destination.
-[[remotes.reduct]]
+[remotes.reduct.local]
 # Unique remote name referenced by pipelines.<name>.remote.
-name = "local"
+
 # ReductStore base URL.
 url = "http://localhost:8383"
 # API token used for authentication.
@@ -12,7 +12,7 @@ bucket = "my-bucket"
 prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
-# [remotes.reduct.create_bucket]
+# [remotes.reduct.local.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
 # quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 

--- a/examples/mqtt_protobuf_config.toml
+++ b/examples/mqtt_protobuf_config.toml
@@ -1,7 +1,7 @@
 # Protobuf MQTT example using descriptor-backed field-path labels.
 
-[[remotes.reduct]]
-name = "local"
+[remotes.reduct.local]
+
 url = "http://localhost:8383"
 token_api = "***"
 bucket = "mqtt-protobuf"

--- a/examples/ros_config.toml
+++ b/examples/ros_config.toml
@@ -1,7 +1,7 @@
 # ReductStore remote destination.
-[[remotes.reduct]]
+[remotes.reduct.local]
 # Unique remote name referenced by pipelines.<name>.remote.
-name = "local"
+
 # ReductStore base URL.
 url = "http://localhost:8383"
 # API token used for authentication.
@@ -19,7 +19,7 @@ batch_max_size_bytes = 8388608
 batch_max_interval_ms = 1000
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
-# [remotes.reduct.create_bucket]
+# [remotes.reduct.local.create_bucket]
 # quota_type = "FIFO" # NONE, FIFO, or HARD
 # quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -26,27 +26,43 @@ pub fn find_named_entry<'a>(
         .and_then(Value::as_table)
         .with_context(|| format!("Missing '{section}' section in configuration"))?;
 
+    let mut matched: Option<(&str, &Table)> = None;
+
     for (entry_type, entries) in section_table {
-        let Some(entries) = entries.as_array() else {
-            continue;
-        };
+        if let Some(entries) = entries.as_array() {
+            for entry in entries {
+                let Some(entry_table) = entry.as_table() else {
+                    continue;
+                };
 
-        for entry in entries {
-            let Some(entry_table) = entry.as_table() else {
-                continue;
-            };
+                if entry_table
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|name| name == target_name)
+                {
+                    if matched.is_some() {
+                        bail!(
+                            "Duplicate [{section}.*] entry named '{target_name}' found across configuration forms"
+                        );
+                    }
+                    matched = Some((entry_type.as_str(), entry_table));
+                }
+            }
+        }
 
-            if entry_table
-                .get("name")
-                .and_then(Value::as_str)
-                .is_some_and(|name| name == target_name)
-            {
-                return Ok((entry_type.as_str(), entry_table));
+        if let Some(entries_table) = entries.as_table() {
+            if let Some(entry_table) = entries_table.get(target_name).and_then(Value::as_table) {
+                if matched.is_some() {
+                    bail!(
+                        "Duplicate [{section}.*] entry named '{target_name}' found across configuration forms"
+                    );
+                }
+                matched = Some((entry_type.as_str(), entry_table));
             }
         }
     }
 
-    bail!("Missing [[{section}.*]] entry named '{target_name}'")
+    matched.ok_or_else(|| anyhow::anyhow!("Missing [[{section}.*]] entry named '{target_name}'"))
 }
 
 pub fn find_keyed_entry<'a>(
@@ -86,4 +102,67 @@ pub fn parse_config_file(path: impl AsRef<Path>) -> Result<Value, Error> {
     let config: Value = toml::from_str(&config_text)
         .with_context(|| format!("Failed to parse TOML config from {}", path.display()))?;
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_named_entry;
+    use toml::Value;
+
+    #[test]
+    fn finds_named_entry_in_array_of_tables() {
+        let cfg: Value = toml::from_str(
+            r#"
+[remotes]
+[[remotes.reduct]]
+name = "local"
+url = "http://localhost:8383"
+"#,
+        )
+        .expect("parse");
+
+        let (kind, table) = find_named_entry(&cfg, "remotes", "local").expect("find");
+        assert_eq!(kind, "reduct");
+        assert_eq!(
+            table.get("url").and_then(Value::as_str),
+            Some("http://localhost:8383")
+        );
+    }
+
+    #[test]
+    fn finds_named_entry_in_keyed_table() {
+        let cfg: Value = toml::from_str(
+            r#"
+[remotes.reduct.local]
+url = "http://localhost:8383"
+"#,
+        )
+        .expect("parse");
+
+        let (kind, table) = find_named_entry(&cfg, "remotes", "local").expect("find");
+        assert_eq!(kind, "reduct");
+        assert_eq!(
+            table.get("url").and_then(Value::as_str),
+            Some("http://localhost:8383")
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_name_in_array_of_tables() {
+        let cfg: Value = toml::from_str(
+            r#"
+[[remotes.reduct]]
+name = "local"
+url = "http://localhost:8383"
+
+[[remotes.reduct]]
+name = "local"
+url = "http://localhost:8384"
+"#,
+        )
+        .expect("parse");
+
+        let err = find_named_entry(&cfg, "remotes", "local").expect_err("duplicate must fail");
+        assert!(err.to_string().contains("Duplicate"));
+    }
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use anyhow::{Context, Error, bail};
+use log::warn;
 use serde::de::DeserializeOwned;
 use std::path::Path;
 use toml::{Value, value::Table};
@@ -45,6 +46,10 @@ pub fn find_named_entry<'a>(
                             "Duplicate [{section}.*] entry named '{target_name}' found across configuration forms"
                         );
                     }
+                    warn!(
+                        "Deprecated array-of-tables syntax [[{}.{}]] with name='{}' detected; prefer keyed syntax [{}.{}.{}]",
+                        section, entry_type, target_name, section, entry_type, target_name
+                    );
                     matched = Some((entry_type.as_str(), entry_table));
                 }
             }

--- a/src/remote/reduct/README.md
+++ b/src/remote/reduct/README.md
@@ -6,10 +6,10 @@ Use this remote to write pipeline data to ReductStore.
 
 ```toml
 # Remote definition path:
-[[remotes.reduct]]
+[remotes.reduct.local]
 
 # Required: unique remote name referenced by pipelines.<name>.remote.
-name = "local"
+
 
 # Required: ReductStore base URL.
 url = "http://localhost:8383"
@@ -36,7 +36,7 @@ batch_max_interval_ms = 1000
 
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
-[remotes.reduct.create_bucket]
+[remotes.reduct.local.create_bucket]
 # Required when create_bucket is configured: NONE, FIFO, or HARD.
 quota_type = "FIFO"
 
@@ -51,7 +51,7 @@ quota_size = "1GB"
 
 - Records are buffered and flushed by count, size, or interval.
 - Invalid batching values (`0`) are not allowed.
-- Buckets are not created automatically unless `[remotes.reduct.create_bucket]` is configured.
+- Buckets are not created automatically unless `[remotes.reduct.local.create_bucket]` is configured.
 - Automatic bucket creation only applies when the configured bucket is missing; existing bucket settings are not changed.
 
 ## Changes

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -82,7 +82,7 @@ impl ReductInstance {
             Err(err) if err.status() == ErrorCode::NotFound => {
                 let Some(create_bucket) = &cfg.create_bucket else {
                     bail!(
-                        "Failed to access bucket '{}': bucket does not exist. Configure [remotes.reduct.create_bucket] to create it automatically.",
+                        "Failed to access bucket '{}': bucket does not exist. Configure [remotes.reduct.<name>.create_bucket] to create it automatically.",
                         cfg.bucket
                     );
                 };
@@ -296,6 +296,19 @@ mod config_tests {
     fn build_remote_config(create_bucket: &str) -> String {
         format!(
             r#"
+[remotes.reduct.local]
+url = "http://localhost:8383"
+token_api = ""
+bucket = "my-bucket"
+prefix = ""
+{create_bucket}
+"#
+        )
+    }
+
+    fn build_legacy_remote_config(create_bucket: &str) -> String {
+        format!(
+            r#"
 [[remotes.reduct]]
 name = "local"
 url = "http://localhost:8383"
@@ -318,7 +331,7 @@ prefix = ""
         let cfg = parse_reduct_remote_config(&build_remote_config(&format!(
             r#"
 
-[remotes.reduct.create_bucket]
+[remotes.reduct.local.create_bucket]
 quota_type = "FIFO"
 quota_size = {quota_size}
 "#
@@ -337,7 +350,7 @@ quota_size = {quota_size}
         let err = parse_reduct_remote_config(&build_remote_config(&format!(
             r#"
 
-[remotes.reduct.create_bucket]
+[remotes.reduct.local.create_bucket]
 quota_type = "FIFO"
 quota_size = {quota_size}
 "#
@@ -354,6 +367,14 @@ quota_size = {quota_size}
             parse_reduct_remote_config(&build_remote_config("")).expect("parse remote config");
 
         assert!(cfg.create_bucket.is_none());
+    }
+
+    #[test]
+    fn keeps_legacy_array_of_tables_format_compatible() {
+        let cfg = parse_reduct_remote_config(&build_legacy_remote_config(""))
+            .expect("parse legacy remote config");
+
+        assert_eq!(cfg.bucket, "my-bucket");
     }
 }
 


### PR DESCRIPTION
Closes #41

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature + docs update

### What was changed?

- Added support for keyed TOML table syntax for Reduct remotes: `[remotes.reduct.<name>]`.
- Kept existing `[[remotes.reduct]]` array-of-tables format compatible.
- Extended config lookup logic so remote selection works with both forms.
- Added duplicate-name protection for array-of-tables entries.
- Added/updated unit tests for both formats and legacy compatibility.
- Updated Reduct remote docs/examples to show keyed table syntax as preferred.

### Related issues

- https://github.com/reductstore/reduct-bridge/issues/41
- Plan comment: https://github.com/reductstore/reduct-bridge/issues/41#issuecomment-4552011977

### Does this PR introduce a breaking change?

No. Existing `[[remotes.reduct]]` configs continue to work.

### Other information:

- Verified with:
  - `cargo test cfg::tests:: --quiet`
  - `cargo test config_tests:: --quiet`
