### PR TITLE
feat: improve create_bucket quota UX for NONE mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional ReductStore bucket creation via `[remotes.reduct.create_bucket]`, with configurable `quota_type`, numeric or human-readable `quota_size` values such as `"1GB"` and `"4GiB"`, updated examples/docs, and parsing coverage for valid and invalid unit strings, [PR-34](https://github.com/reductstore/reduct-bridge/pull/34).
 - Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
 - Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, now with deprecation warnings when the legacy array syntax is used, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
+- Improved Reduct `create_bucket` quota UX by defaulting `quota_type` to `NONE`, requiring `quota_size` only for `FIFO`/`HARD`, and aligning launch/config validation and docs with this behavior, [PR-43](https://github.com/reductstore/reduct-bridge/pull/43).
 
 ## 0.2.1 - 2026-05-19
 

--- a/examples/http_config.toml
+++ b/examples/http_config.toml
@@ -13,8 +13,8 @@ prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.local.create_bucket]
-# quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+# quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
+# quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 # HTTP input configuration.
 # Structure: [inputs.http.<input_name>]

--- a/examples/metric_config.toml
+++ b/examples/metric_config.toml
@@ -13,8 +13,8 @@ prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.local.create_bucket]
-# quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+# quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
+# quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 # Metrics input configuration.
 # Structure: [inputs.metrics.<input_name>]

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -13,8 +13,8 @@ prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.local.create_bucket]
-# quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+# quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
+# quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 
 # MQTT v5 input configuration.

--- a/examples/ros_config.toml
+++ b/examples/ros_config.toml
@@ -20,8 +20,8 @@ batch_max_interval_ms = 1000
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 # [remotes.reduct.local.create_bucket]
-# quota_type = "FIFO" # NONE, FIFO, or HARD
-# quota_size = "1GB" # also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+# quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
+# quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 
 # ROS1 input configuration.

--- a/src/remote/reduct/README.md
+++ b/src/remote/reduct/README.md
@@ -37,10 +37,10 @@ batch_max_interval_ms = 1000
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 [remotes.reduct.local.create_bucket]
-# Required when create_bucket is configured: NONE, FIFO, or HARD.
+# Optional when create_bucket is configured: NONE, FIFO, or HARD (default: NONE).
 quota_type = "FIFO"
 
-# Required when create_bucket is configured: quota size as bytes or a unit string.
+# Required only for FIFO/HARD quota types.
 # Accepted examples: 1073741824, "1GB", "512MB", "4GiB", "1.5TiB", "500 B".
 # Accepted decimal units: B, K/KB, M/MB, G/GB, T/TB, P/PB, E/EB.
 # Accepted binary units: Ki/KiB, Mi/MiB, Gi/GiB, Ti/TiB, Pi/PiB, Ei/EiB.

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -50,8 +50,10 @@ pub struct RemoteConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateBucketConfig {
+    #[serde(default = "default_quota_type")]
     pub quota_type: QuotaType,
-    pub quota_size: ByteSize,
+    #[serde(default)]
+    pub quota_size: Option<ByteSize>,
 }
 
 pub struct ReductInstance {
@@ -68,6 +70,10 @@ fn default_batch_max_interval_ms() -> u64 {
 
 fn default_batch_max_size_bytes() -> usize {
     DEFAULT_BATCH_MAX_SIZE_BYTES
+}
+
+fn default_quota_type() -> QuotaType {
+    QuotaType::NONE
 }
 
 impl ReductInstance {
@@ -88,14 +94,24 @@ impl ReductInstance {
                 };
 
                 info!(
-                    "Bucket '{}' does not exist, creating it with quota type {:?} and quota size {} bytes",
-                    cfg.bucket, create_bucket.quota_type, create_bucket.quota_size
+                    "Bucket '{}' does not exist, creating it with quota type {:?}{}",
+                    cfg.bucket,
+                    create_bucket.quota_type,
+                    create_bucket
+                        .quota_size
+                        .map(|size| format!(" and quota size {} bytes", size))
+                        .unwrap_or_default()
                 );
 
-                client
+                let mut request = client
                     .create_bucket(&cfg.bucket)
-                    .quota_type(create_bucket.quota_type.clone())
-                    .quota_size(create_bucket.quota_size.as_u64())
+                    .quota_type(create_bucket.quota_type.clone());
+
+                if let Some(quota_size) = create_bucket.quota_size {
+                    request = request.quota_size(quota_size.as_u64());
+                }
+
+                request
                     .exist_ok(true)
                     .send()
                     .await
@@ -205,8 +221,17 @@ impl RemoteInstanceLauncher for ReductInstance {
             bail!("Reduct remote batch_max_interval_ms must be greater than 0");
         }
         if let Some(create_bucket) = &cfg.create_bucket {
-            if create_bucket.quota_size.as_u64() == 0 {
-                bail!("Reduct remote create_bucket.quota_size must be greater than 0");
+            if matches!(create_bucket.quota_type, QuotaType::FIFO | QuotaType::HARD)
+                && create_bucket.quota_size.is_none()
+            {
+                bail!(
+                    "Reduct remote create_bucket.quota_size is required when create_bucket.quota_type is FIFO or HARD"
+                );
+            }
+            if let Some(quota_size) = create_bucket.quota_size {
+                if quota_size.as_u64() == 0 {
+                    bail!("Reduct remote create_bucket.quota_size must be greater than 0");
+                }
             }
         }
 
@@ -340,7 +365,7 @@ quota_size = {quota_size}
 
         let create_bucket = cfg.create_bucket.expect("create_bucket config");
         assert_eq!(create_bucket.quota_type, QuotaType::FIFO);
-        assert_eq!(create_bucket.quota_size, expected_size);
+        assert_eq!(create_bucket.quota_size, Some(expected_size));
     }
 
     #[rstest]
@@ -362,6 +387,21 @@ quota_size = {quota_size}
     }
 
     #[test]
+    fn defaults_create_bucket_quota_type_to_none_and_makes_size_optional() {
+        let cfg = parse_reduct_remote_config(&build_remote_config(
+            r#"
+
+[remotes.reduct.local.create_bucket]
+"#,
+        ))
+        .expect("parse remote config");
+
+        let create_bucket = cfg.create_bucket.expect("create_bucket config");
+        assert_eq!(create_bucket.quota_type, QuotaType::NONE);
+        assert_eq!(create_bucket.quota_size, None);
+    }
+
+    #[test]
     fn omits_create_bucket_config_by_default() {
         let cfg =
             parse_reduct_remote_config(&build_remote_config("")).expect("parse remote config");
@@ -380,7 +420,10 @@ quota_size = {quota_size}
 
 #[cfg(test)]
 mod unit_tests {
-    use super::ReductInstance;
+    use super::{CreateBucketConfig, ReductInstance, RemoteConfig};
+    use crate::remote::RemoteInstanceLauncher;
+    use bytesize::ByteSize;
+    use reduct_rs::QuotaType;
 
     #[test]
     fn normalize_entry_path_collapses_extra_slashes() {
@@ -393,6 +436,70 @@ mod unit_tests {
             Some("root/a/b".to_string())
         );
         assert_eq!(ReductInstance::normalize_entry_path("/", "//"), None);
+    }
+
+    fn base_remote_config(create_bucket: Option<CreateBucketConfig>) -> RemoteConfig {
+        RemoteConfig {
+            url: "http://127.0.0.1:8383".to_string(),
+            token_api: "".to_string(),
+            bucket: "bucket".to_string(),
+            prefix: "".to_string(),
+            batch_max_records: 1,
+            batch_max_size_bytes: 1,
+            batch_max_interval_ms: 1,
+            create_bucket,
+        }
+    }
+
+    #[tokio::test]
+    async fn launch_rejects_fifo_without_quota_size() {
+        let remote = ReductInstance::new(base_remote_config(Some(CreateBucketConfig {
+            quota_type: QuotaType::FIFO,
+            quota_size: None,
+        })));
+
+        let err = remote
+            .launch()
+            .await
+            .expect_err("FIFO without quota size should fail validation");
+        assert!(
+            err.to_string().contains("quota_size is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_allows_none_without_quota_size() {
+        let remote = ReductInstance::new(base_remote_config(Some(CreateBucketConfig {
+            quota_type: QuotaType::NONE,
+            quota_size: None,
+        })));
+
+        let err = remote
+            .launch()
+            .await
+            .expect_err("launch should fail later because server is unavailable");
+        assert!(
+            !err.to_string().contains("quota_size is required"),
+            "unexpected validation error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_rejects_zero_quota_size() {
+        let remote = ReductInstance::new(base_remote_config(Some(CreateBucketConfig {
+            quota_type: QuotaType::HARD,
+            quota_size: Some(ByteSize(0)),
+        })));
+
+        let err = remote
+            .launch()
+            .await
+            .expect_err("zero quota size should fail validation");
+        assert!(
+            err.to_string().contains("must be greater than 0"),
+            "unexpected error: {err}"
+        );
     }
 }
 
@@ -525,7 +632,7 @@ mod ci_tests {
             bucket_name.clone(),
             Some(CreateBucketConfig {
                 quota_type: QuotaType::FIFO,
-                quota_size: ByteSize(1024 * 1024 * 1024),
+                quota_size: Some(ByteSize(1024 * 1024 * 1024)),
             }),
         ));
 
@@ -563,7 +670,7 @@ mod ci_tests {
             bucket_name.clone(),
             Some(CreateBucketConfig {
                 quota_type: QuotaType::FIFO,
-                quota_size: ByteSize(1024 * 1024 * 1024),
+                quota_size: Some(ByteSize(1024 * 1024 * 1024)),
             }),
         ));
 

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -475,14 +475,12 @@ mod unit_tests {
             quota_size: None,
         })));
 
-        let err = remote
-            .launch()
-            .await
-            .expect_err("launch should fail later because server is unavailable");
-        assert!(
-            !err.to_string().contains("quota_size is required"),
-            "unexpected validation error: {err}"
-        );
+        if let Err(err) = remote.launch().await {
+            assert!(
+                !err.to_string().contains("quota_size is required"),
+                "unexpected validation error: {err}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #40

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature + config/validation UX improvement for remote bucket creation settings.

### What was changed?

- Made `remotes.reduct.<name>.create_bucket.quota_type` optional with default `NONE`.
- Made `quota_size` optional in config parsing.
- Added conditional validation at launch time:
  - `quota_size` is required for `FIFO` and `HARD` quota types.
  - `quota_size` remains optional for `NONE`.
  - `quota_size = 0` is still rejected.
- Updated bucket creation logic to set quota size only when provided.
- Added/updated tests for parsing defaults and runtime validation behavior.
- Updated Reduct remote docs and example configs to reflect the new optional/conditional quota fields.

### Related issues

- https://github.com/reductstore/reduct-bridge/issues/40
- Plan comment: https://github.com/reductstore/reduct-bridge/issues/40#issuecomment-4553092239

### Does this PR introduce a breaking change?

No. Existing configs with explicit `quota_type`/`quota_size` continue to work. This change relaxes config requirements when quota type is `NONE`.

### Other information:

Validation/tests run locally:

- `cargo test -q config_tests`
- `cargo test -q unit_tests`
