### PR TITLE
feat: periodically resend missing reduct attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
 - Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, now with deprecation warnings when the legacy array syntax is used, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
 - Improved Reduct `create_bucket` quota UX by defaulting `quota_type` to `NONE`, requiring `quota_size` only for `FIFO`/`HARD`, and aligning launch/config validation and docs with this behavior, [PR-43](https://github.com/reductstore/reduct-bridge/pull/43).
-- Reduct remote attachment reconciliation with `attachments_resend_interval_ms` (default `300000`, `0` disables) to periodically restore missing attachments, including config/docs coverage and CI tests for enabled/disabled behavior.
+- Reduct remote attachment reconciliation with `attachments_resend_interval_ms` (default `300000`, `0` disables) to periodically restore missing attachments, including config/docs coverage and CI tests for enabled/disabled behavior, [PR-45](https://github.com/reductstore/reduct-bridge/pull/45).
 
 ## 0.2.1 - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bundle-style `ros1`, `ros2`, and `iot` build features with CI and installation documentation updates, [PR-37](https://github.com/reductstore/reduct-bridge/pull/37).
 - Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, now with deprecation warnings when the legacy array syntax is used, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
 - Improved Reduct `create_bucket` quota UX by defaulting `quota_type` to `NONE`, requiring `quota_size` only for `FIFO`/`HARD`, and aligning launch/config validation and docs with this behavior, [PR-43](https://github.com/reductstore/reduct-bridge/pull/43).
+- Reduct remote attachment reconciliation with `attachments_resend_interval_ms` (default `300000`, `0` disables) to periodically restore missing attachments, including config/docs coverage and CI tests for enabled/disabled behavior.
 
 ## 0.2.1 - 2026-05-19
 

--- a/src/remote/reduct/README.md
+++ b/src/remote/reduct/README.md
@@ -34,6 +34,11 @@ batch_max_size_bytes = 8388608
 # Periodic flush interval in milliseconds (default: 1000, must be > 0).
 batch_max_interval_ms = 1000
 
+# Optional: periodically resend missing attachments for known entries.
+# Default: 300000 (enabled, every 5 minutes).
+# Set to 0 to disable periodic resend.
+attachments_resend_interval_ms = 300000
+
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
 [remotes.reduct.local.create_bucket]
@@ -50,6 +55,8 @@ quota_size = "1GB"
 ## Runtime Notes
 
 - Records are buffered and flushed by count, size, or interval.
+- `attachments_resend_interval_ms` defaults to `300000` (enabled). Set it to `0` to disable periodic attachment resend.
+- The resend loop writes only missing attachment keys for entries already observed by this running bridge instance.
 - Invalid batching values (`0`) are not allowed.
 - Buckets are not created automatically unless `[remotes.reduct.local.create_bucket]` is configured.
 - Automatic bucket creation only applies when the configured bucket is missing; existing bucket settings are not changed.

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -896,12 +896,11 @@ mod ci_tests {
 
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         for _ in 0..10 {
-            let attachments = bucket
-                .read_attachments("it/entry")
-                .await
-                .expect("read attachments");
-            if attachments.contains_key("$ros") {
-                break;
+            match bucket.read_attachments("it/entry").await {
+                Ok(attachments) if attachments.contains_key("$ros") => break,
+                Ok(_) => {}
+                Err(err) if err.status() == ErrorCode::NotFound => {}
+                Err(err) => panic!("read attachments: {err:?}"),
             }
             sleep(Duration::from_millis(50)).await;
         }
@@ -913,13 +912,14 @@ mod ci_tests {
 
         let mut restored = false;
         for _ in 0..20 {
-            let attachments = bucket
-                .read_attachments("it/entry")
-                .await
-                .expect("read attachments");
-            if attachments.contains_key("$ros") {
-                restored = true;
-                break;
+            match bucket.read_attachments("it/entry").await {
+                Ok(attachments) if attachments.contains_key("$ros") => {
+                    restored = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) if err.status() == ErrorCode::NotFound => {}
+                Err(err) => panic!("read attachments: {err:?}"),
             }
             sleep(Duration::from_millis(50)).await;
         }
@@ -958,12 +958,11 @@ mod ci_tests {
 
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         for _ in 0..10 {
-            let attachments = bucket
-                .read_attachments("it/entry")
-                .await
-                .expect("read attachments");
-            if attachments.contains_key("$ros") {
-                break;
+            match bucket.read_attachments("it/entry").await {
+                Ok(attachments) if attachments.contains_key("$ros") => break,
+                Ok(_) => {}
+                Err(err) if err.status() == ErrorCode::NotFound => {}
+                Err(err) => panic!("read attachments: {err:?}"),
             }
             sleep(Duration::from_millis(50)).await;
         }
@@ -978,10 +977,10 @@ mod ci_tests {
         runtime.tx.send(Message::Stop).await.expect("send stop");
         runtime.task.await.expect("join remote");
 
-        let attachments = bucket
-            .read_attachments("it/entry")
-            .await
-            .expect("read attachments");
-        assert!(!attachments.contains_key("$ros"));
+        match bucket.read_attachments("it/entry").await {
+            Ok(attachments) => assert!(!attachments.contains_key("$ros")),
+            Err(err) if err.status() == ErrorCode::NotFound => {}
+            Err(err) => panic!("read attachments: {err:?}"),
+        }
     }
 }

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -618,7 +618,7 @@ mod ci_tests {
     use bytes::Bytes;
     use bytesize::ByteSize;
     use futures_util::StreamExt;
-    use reduct_rs::{QuotaType, ReductClient};
+    use reduct_rs::{ErrorCode, QuotaType, ReductClient};
     use rstest::{fixture, rstest};
     #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     use serde_json::json;

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -30,6 +30,7 @@ const CHANNEL_SIZE: usize = 1024;
 const DEFAULT_BATCH_MAX_RECORDS: usize = 80;
 const DEFAULT_BATCH_MAX_SIZE_BYTES: usize = 8 * 1024 * 1024;
 const DEFAULT_BATCH_MAX_INTERVAL_MS: u64 = 1000;
+const DEFAULT_ATTACHMENTS_RESEND_INTERVAL_MS: u64 = 300_000;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct RemoteConfig {
@@ -43,6 +44,8 @@ pub struct RemoteConfig {
     pub batch_max_size_bytes: usize,
     #[serde(default = "default_batch_max_interval_ms")]
     pub batch_max_interval_ms: u64,
+    #[serde(default = "default_attachments_resend_interval_ms")]
+    pub attachments_resend_interval_ms: u64,
 
     #[serde(default)]
     pub create_bucket: Option<CreateBucketConfig>,
@@ -70,6 +73,10 @@ fn default_batch_max_interval_ms() -> u64 {
 
 fn default_batch_max_size_bytes() -> usize {
     DEFAULT_BATCH_MAX_SIZE_BYTES
+}
+
+fn default_attachments_resend_interval_ms() -> u64 {
+    DEFAULT_ATTACHMENTS_RESEND_INTERVAL_MS
 }
 
 fn default_quota_type() -> QuotaType {
@@ -190,7 +197,7 @@ impl ReductInstance {
     }
 
     #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
-    async fn write_attachment(cfg: &RemoteConfig, bucket: &Bucket, attachment: Attachment) {
+    async fn write_attachment(cfg: &RemoteConfig, bucket: &Bucket, attachment: &Attachment) {
         let Some(entry) = Self::normalize_entry_path(&cfg.prefix, &attachment.entry_name) else {
             warn!(
                 "Skipping attachment with invalid entry path prefix='{}' entry_name='{}'",
@@ -200,9 +207,67 @@ impl ReductInstance {
         };
 
         let mut attachments = std::collections::HashMap::new();
-        attachments.insert(attachment.key, attachment.payload);
+        attachments.insert(attachment.key.clone(), attachment.payload.clone());
         if let Err(err) = bucket.write_attachments(&entry, attachments).await {
             warn!("Failed to write attachment for entry '{}': {}", entry, err);
+        }
+    }
+
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
+    fn update_attachment_cache(
+        cfg: &RemoteConfig,
+        cache: &mut std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, serde_json::Value>,
+        >,
+        attachment: &Attachment,
+    ) {
+        let Some(entry) = Self::normalize_entry_path(&cfg.prefix, &attachment.entry_name) else {
+            return;
+        };
+
+        cache
+            .entry(entry)
+            .or_default()
+            .insert(attachment.key.clone(), attachment.payload.clone());
+    }
+
+    async fn resend_missing_attachments(
+        bucket: &Bucket,
+        cache: &std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, serde_json::Value>,
+        >,
+    ) {
+        for (entry, cached_attachments) in cache {
+            let existing_attachments = match bucket.read_attachments(entry).await {
+                Ok(attachments) => attachments,
+                Err(err) => {
+                    warn!(
+                        "Failed to read attachments for entry '{}' during periodic resend: {}",
+                        entry, err
+                    );
+                    continue;
+                }
+            };
+
+            let mut missing_attachments = std::collections::HashMap::new();
+            for (key, payload) in cached_attachments {
+                if !existing_attachments.contains_key(key) {
+                    missing_attachments.insert(key.clone(), payload.clone());
+                }
+            }
+
+            if missing_attachments.is_empty() {
+                continue;
+            }
+
+            if let Err(err) = bucket.write_attachments(entry, missing_attachments).await {
+                warn!(
+                    "Failed to resend missing attachments for entry '{}': {}",
+                    entry, err
+                );
+            }
         }
     }
 }
@@ -243,13 +308,14 @@ impl RemoteInstanceLauncher for ReductInstance {
         let (tx, mut rx) = channel::<Message>(CHANNEL_SIZE);
         let bucket: Bucket = Self::resolve_bucket(&client, &cfg).await?;
         info!(
-            "Launching Reduct remote '{}' bucket '{}' prefix '{}' batch >{} records, >{} bytes, every {}ms",
+            "Launching Reduct remote '{}' bucket '{}' prefix '{}' batch >{} records, >{} bytes, every {}ms; attachments resend interval {}ms (0 disables)",
             cfg.url,
             cfg.bucket,
             cfg.prefix,
             cfg.batch_max_records,
             cfg.batch_max_size_bytes,
-            cfg.batch_max_interval_ms
+            cfg.batch_max_interval_ms,
+            cfg.attachments_resend_interval_ms,
         );
 
         let task = tokio::spawn(async move {
@@ -257,6 +323,18 @@ impl RemoteInstanceLauncher for ReductInstance {
             let mut batch = bucket.write_record_batch();
             let mut flush_ticker = interval(Duration::from_millis(cfg.batch_max_interval_ms));
             flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            let mut attachment_cache = std::collections::HashMap::<
+                String,
+                std::collections::HashMap<String, serde_json::Value>,
+            >::new();
+            let mut attachments_resend_ticker = if cfg.attachments_resend_interval_ms > 0 {
+                let mut ticker =
+                    interval(Duration::from_millis(cfg.attachments_resend_interval_ms));
+                ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                Some(ticker)
+            } else {
+                None
+            };
 
             loop {
                 tokio::select! {
@@ -274,7 +352,8 @@ impl RemoteInstanceLauncher for ReductInstance {
                             }
                             #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
                             Some(Message::Attachment(attachment)) => {
-                                Self::write_attachment(&cfg, &bucket, attachment).await;
+                                Self::write_attachment(&cfg, &bucket, &attachment).await;
+                                Self::update_attachment_cache(&cfg, &mut attachment_cache, &attachment);
                             }
                             Some(Message::Stop) => {
                                 info!("Stop message received, flushing Reduct batch before shutdown");
@@ -287,6 +366,16 @@ impl RemoteInstanceLauncher for ReductInstance {
                                 break;
                             }
                         }
+                    }
+                    _ = async {
+                        match attachments_resend_ticker.as_mut() {
+                            Some(ticker) => {
+                                ticker.tick().await;
+                            }
+                            None => std::future::pending::<()>().await,
+                        }
+                    } => {
+                        Self::resend_missing_attachments(&bucket, &attachment_cache).await;
                     }
                     _ = flush_ticker.tick() => {
                         if batch.record_count() > 0 {
@@ -410,6 +499,23 @@ quota_size = {quota_size}
     }
 
     #[test]
+    fn defaults_attachments_resend_interval_to_enabled_5_minutes() {
+        let cfg =
+            parse_reduct_remote_config(&build_remote_config("")).expect("parse remote config");
+
+        assert_eq!(cfg.attachments_resend_interval_ms, 300_000);
+    }
+
+    #[test]
+    fn parses_zero_attachments_resend_interval_as_disabled() {
+        let cfg =
+            parse_reduct_remote_config(&build_remote_config("attachments_resend_interval_ms = 0"))
+                .expect("parse remote config");
+
+        assert_eq!(cfg.attachments_resend_interval_ms, 0);
+    }
+
+    #[test]
     fn keeps_legacy_array_of_tables_format_compatible() {
         let cfg = parse_reduct_remote_config(&build_legacy_remote_config(""))
             .expect("parse legacy remote config");
@@ -447,6 +553,7 @@ mod unit_tests {
             batch_max_records: 1,
             batch_max_size_bytes: 1,
             batch_max_interval_ms: 1,
+            attachments_resend_interval_ms: 300_000,
             create_bucket,
         }
     }
@@ -504,7 +611,7 @@ mod unit_tests {
 #[cfg(all(test, feature = "ci"))]
 mod ci_tests {
     use super::{CreateBucketConfig, ReductInstance, RemoteConfig};
-    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     use crate::message::Attachment;
     use crate::message::{Message, Record};
     use crate::remote::RemoteInstanceLauncher;
@@ -513,7 +620,7 @@ mod ci_tests {
     use futures_util::StreamExt;
     use reduct_rs::{QuotaType, ReductClient};
     use rstest::{fixture, rstest};
-    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     use serde_json::json;
     use std::collections::HashMap;
     use std::env;
@@ -556,6 +663,7 @@ mod ci_tests {
         url: String,
         bucket: String,
         create_bucket: Option<CreateBucketConfig>,
+        attachments_resend_interval_ms: u64,
     ) -> RemoteConfig {
         RemoteConfig {
             url,
@@ -565,6 +673,7 @@ mod ci_tests {
             batch_max_records: 10,
             batch_max_size_bytes: 1024 * 1024,
             batch_max_interval_ms: 50,
+            attachments_resend_interval_ms,
             create_bucket,
         }
     }
@@ -602,7 +711,7 @@ mod ci_tests {
         })
     }
 
-    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     #[fixture]
     fn ros_attachment_message() -> Message {
         Message::Attachment(Attachment {
@@ -632,6 +741,7 @@ mod ci_tests {
                 quota_type: QuotaType::FIFO,
                 quota_size: Some(ByteSize(1024 * 1024 * 1024)),
             }),
+            300_000,
         ));
 
         write_data_and_stop(remote, data_message).await;
@@ -670,6 +780,7 @@ mod ci_tests {
                 quota_type: QuotaType::FIFO,
                 quota_size: Some(ByteSize(1024 * 1024 * 1024)),
             }),
+            300_000,
         ));
 
         write_data_and_stop(remote, data_message).await;
@@ -693,7 +804,7 @@ mod ci_tests {
         let url = reductstore_url();
         let _client = reductstore_client().await;
 
-        let remote = ReductInstance::new(remote_config(url, bucket_name, None));
+        let remote = ReductInstance::new(remote_config(url, bucket_name, None, 300_000));
         let err = remote
             .launch()
             .await
@@ -707,7 +818,7 @@ mod ci_tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     async fn ci_reductstore_roundtrip_data_and_attachment(
         data_message: Message,
         ros_attachment_message: Message,
@@ -724,7 +835,7 @@ mod ci_tests {
             .await
             .expect("create bucket");
 
-        let remote = ReductInstance::new(remote_config(url, bucket_name.clone(), None));
+        let remote = ReductInstance::new(remote_config(url, bucket_name.clone(), None, 300_000));
 
         let runtime = remote.launch().await.expect("launch remote");
         runtime.tx.send(data_message).await.expect("send data");
@@ -755,5 +866,122 @@ mod ci_tests {
         assert_eq!(payload["encoding"], "ros1");
         assert_eq!(payload["topic"], "/sensor/pos");
         assert_eq!(payload["schema_name"], "geometry_msgs/Point");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
+    async fn ci_reductstore_resends_removed_attachment_when_enabled(
+        ros_attachment_message: Message,
+    ) {
+        let suffix = unique_suffix();
+        let bucket_name = format!("it-{suffix}");
+        let url = reductstore_url();
+        let client = reductstore_client().await;
+
+        client
+            .create_bucket(&bucket_name)
+            .exist_ok(true)
+            .send()
+            .await
+            .expect("create bucket");
+
+        let remote = ReductInstance::new(remote_config(url, bucket_name.clone(), None, 50));
+        let runtime = remote.launch().await.expect("launch remote");
+        runtime
+            .tx
+            .send(ros_attachment_message)
+            .await
+            .expect("send attachment");
+
+        let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
+        for _ in 0..10 {
+            let attachments = bucket
+                .read_attachments("it/entry")
+                .await
+                .expect("read attachments");
+            if attachments.contains_key("$ros") {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        bucket
+            .remove_attachments("it/entry", None)
+            .await
+            .expect("remove attachments");
+
+        let mut restored = false;
+        for _ in 0..20 {
+            let attachments = bucket
+                .read_attachments("it/entry")
+                .await
+                .expect("read attachments");
+            if attachments.contains_key("$ros") {
+                restored = true;
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        runtime.tx.send(Message::Stop).await.expect("send stop");
+        runtime.task.await.expect("join remote");
+
+        assert!(restored, "expected $ros attachment to be resent");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
+    async fn ci_reductstore_does_not_resend_removed_attachment_when_disabled(
+        ros_attachment_message: Message,
+    ) {
+        let suffix = unique_suffix();
+        let bucket_name = format!("it-{suffix}");
+        let url = reductstore_url();
+        let client = reductstore_client().await;
+
+        client
+            .create_bucket(&bucket_name)
+            .exist_ok(true)
+            .send()
+            .await
+            .expect("create bucket");
+
+        let remote = ReductInstance::new(remote_config(url, bucket_name.clone(), None, 0));
+        let runtime = remote.launch().await.expect("launch remote");
+        runtime
+            .tx
+            .send(ros_attachment_message)
+            .await
+            .expect("send attachment");
+
+        let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
+        for _ in 0..10 {
+            let attachments = bucket
+                .read_attachments("it/entry")
+                .await
+                .expect("read attachments");
+            if attachments.contains_key("$ros") {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        bucket
+            .remove_attachments("it/entry", None)
+            .await
+            .expect("remove attachments");
+
+        sleep(Duration::from_millis(250)).await;
+
+        runtime.tx.send(Message::Stop).await.expect("send stop");
+        runtime.task.await.expect("join remote");
+
+        let attachments = bucket
+            .read_attachments("it/entry")
+            .await
+            .expect("read attachments");
+        assert!(!attachments.contains_key("$ros"));
     }
 }


### PR DESCRIPTION
Closes #39

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added `attachments_resend_interval_ms` to Reduct remote config (`src/remote/reduct/mod.rs`).
  - Default is `300000` (5 minutes, enabled).
  - Setting `0` disables periodic resend.
- Kept immediate attachment writes unchanged and added an in-memory attachment cache for seen entries.
- Added a periodic reconciliation loop that:
  - reads current target attachments per cached entry,
  - computes missing keys,
  - rewrites only missing attachments.
- Extended config/unit coverage for default and disabled (`0`) behavior.
- Added CI integration tests (feature `ci`) for:
  - resend when enabled,
  - no resend when disabled.
- Updated Reduct remote docs and changelog.

### Related issues

- https://github.com/reductstore/reduct-bridge/issues/39
- Approved implementation plan comment: https://github.com/reductstore/reduct-bridge/issues/39#issuecomment-4556359453

### Does this PR introduce a breaking change?

No API/config format break. Existing configs still parse.

Behavior change: periodic attachment resend is now enabled by default (`attachments_resend_interval_ms = 300000`), which may increase attachment metadata reads/writes. Operators can opt out by setting `attachments_resend_interval_ms = 0`.

### Other information:

Local validation run:

1. `cargo test --no-default-features --features iot` ✅
2. `cargo fmt --all --check` ✅
3. `cargo check --no-default-features --features iot` ✅
