### PR TITLE
Support timestamp mapping from source data fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preferred keyed TOML syntax for Reduct remotes (`[remotes.reduct.<name>]`) while keeping `[[remotes.reduct]]` backward compatible, now with deprecation warnings when the legacy array syntax is used, including updated docs/examples and parser coverage, [PR-42](https://github.com/reductstore/reduct-bridge/pull/42).
 - Improved Reduct `create_bucket` quota UX by defaulting `quota_type` to `NONE`, requiring `quota_size` only for `FIFO`/`HARD`, and aligning launch/config validation and docs with this behavior, [PR-43](https://github.com/reductstore/reduct-bridge/pull/43).
 - Reduct remote attachment reconciliation with `attachments_resend_interval_ms` (default `300000`, `0` disables) to periodically restore missing attachments, including config/docs coverage and CI tests for enabled/disabled behavior, [PR-45](https://github.com/reductstore/reduct-bridge/pull/45).
+- Timestamp mapping from source data fields, headers, and MQTT v5 user properties for HTTP, MQTT, and ROS1 inputs, with shared parsing for Unix, ISO8601, and ROS stamp formats, [PR-46](https://github.com/reductstore/reduct-bridge/pull/46).
 
 ## 0.2.1 - 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "base64",
  "bytes",
  "bytesize 2.3.1",
+ "chrono",
  "env_logger",
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ log = "0.4.28"
 env_logger = "0.11.8"
 regex = "1.12.2"
 serde_json = "1.0.145"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 url = "2.5.7"
 rosrust = { version = "0.9.13", optional = true, git = "https://github.com/reductstore/rosrust.git", tag = "v0.9.13" }
 rclrs = { git = "https://github.com/reductstore/ros2_rust", optional = true, version = "0.7.0" }

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -12,15 +12,15 @@ bucket = "my-bucket"
 prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
- [remotes.reduct.local.create_bucket]
- quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
- quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+# [remotes.reduct.local.create_bucket]
+# quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
+# quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 
 # MQTT v5 input configuration.
 # Structure: [inputs.mqtt.<input_name>]
 [inputs.mqtt.main]
-broker = "mqtt://127.0.0.1:1883"
+broker = "mqtts://broker.example.com:8883"
 client_id = "reduct-bridge"
 version = "v5"
 qos = 1
@@ -31,12 +31,12 @@ password = "${MQTT_PASSWORD}"
 entry_prefix = "/mqtt"
 
 [[inputs.mqtt.main.topics]]
-name = "drift/opcua"
+name = "factory/+/telemetry"
 entry_name = "telemetry"
 content_type = "application/json"
 # Optional timestamp mapping from a payload field. If extraction fails, ingest time is used.
 # Supported formats: unix_s, unix_ms, unix_us, unix_ns, iso8601, ros_stamp.
-timestamp = { field = "id", format = "unix_ms" }
+timestamp = { field = "event_time", format = "unix_ms" }
 # Optional label rules (default = []):
 # 1) Dynamic field label:
 #    { field = "device_id", label = "device" }
@@ -45,43 +45,43 @@ timestamp = { field = "id", format = "unix_ms" }
 # 3) MQTT v5 property label:
 #    { property = "content_type", label = "mime" }
 #    { property = "tenant", label = "tenant" }  # MQTT v5 user property
-#labels = [
-#  { field = "device_id", label = "device" },
-#  { field = "site", label = "site" },
-#  { static = { source = "mqtt" } },
-#  { property = "content_type", label = "mime" },
-#  { property = "tenant", label = "tenant" }
-#]
+labels = [
+  { field = "device_id", label = "device" },
+  { field = "site", label = "site" },
+  { static = { source = "mqtt" } },
+  { property = "content_type", label = "mime" },
+  { property = "tenant", label = "tenant" }
+]
 
-#[[inputs.mqtt.main.topics]]
-#name = "factory/+/events"
-## MQTT v5 user properties can also be used as timestamp sources.
-## timestamp = { property = "event_time", format = "unix_us" }
-#labels = [
-#  { static = { source = "mqtt-events" } }
-#]
+[[inputs.mqtt.main.topics]]
+name = "factory/+/events"
+# MQTT v5 user properties can also be used as timestamp sources.
+# timestamp = { property = "event_time", format = "unix_us" }
+labels = [
+  { static = { source = "mqtt-events" } }
+]
 
 
-## MQTT v3 input configuration.
-#[inputs.mqtt.legacy]
-#broker = "mqtt://broker.example.com:1883"
-#client_id = "reduct-bridge-legacy"
-#version = "v3"
-#qos = 0
-#
-#username = "legacy_user"
-#password = "${LEGACY_MQTT_PASSWORD}"
-#
-#entry_prefix = "/mqtt"
-#
-#[[inputs.mqtt.legacy.topics]]
-#name = "legacy/+/data"
-#entry_name = "legacy"
-#content_type = "application/json"
-#labels = [
-#  { field = "line", label = "line" },
-#  { static = { source = "mqtt-v3" } }
-#]
+# MQTT v3 input configuration.
+[inputs.mqtt.legacy]
+broker = "mqtt://broker.example.com:1883"
+client_id = "reduct-bridge-legacy"
+version = "v3"
+qos = 0
+
+username = "legacy_user"
+password = "${LEGACY_MQTT_PASSWORD}"
+
+entry_prefix = "/mqtt"
+
+[[inputs.mqtt.legacy.topics]]
+name = "legacy/+/data"
+entry_name = "legacy"
+content_type = "application/json"
+labels = [
+  { field = "line", label = "line" },
+  { static = { source = "mqtt-v3" } }
+]
 
 
 # Pipelines
@@ -89,6 +89,6 @@ timestamp = { field = "id", format = "unix_ms" }
 remote = "local"
 inputs = ["main"]
 
-#[pipelines.mqtt_v3_pipeline]
-#remote = "local"
-#inputs = ["legacy"]
+[pipelines.mqtt_v3_pipeline]
+remote = "local"
+inputs = ["legacy"]

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -12,15 +12,15 @@ bucket = "my-bucket"
 prefix = ""
 # Optional: create the bucket on startup if it does not exist.
 # Omit this table to require the bucket to exist before starting reduct-bridge.
-# [remotes.reduct.local.create_bucket]
-# quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
-# quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
+ [remotes.reduct.local.create_bucket]
+ quota_type = "FIFO" # optional, defaults to NONE; valid: NONE, FIFO, HARD
+ quota_size = "1GB" # required only for FIFO/HARD; also accepts raw bytes, MB/GB/TB, or MiB/GiB/TiB
 
 
 # MQTT v5 input configuration.
 # Structure: [inputs.mqtt.<input_name>]
 [inputs.mqtt.main]
-broker = "mqtts://broker.example.com:8883"
+broker = "mqtt://127.0.0.1:1883"
 client_id = "reduct-bridge"
 version = "v5"
 qos = 1
@@ -31,12 +31,12 @@ password = "${MQTT_PASSWORD}"
 entry_prefix = "/mqtt"
 
 [[inputs.mqtt.main.topics]]
-name = "factory/+/telemetry"
+name = "drift/opcua"
 entry_name = "telemetry"
 content_type = "application/json"
 # Optional timestamp mapping from a payload field. If extraction fails, ingest time is used.
 # Supported formats: unix_s, unix_ms, unix_us, unix_ns, iso8601, ros_stamp.
-timestamp = { field = "event_time", format = "unix_ms" }
+timestamp = { field = "id", format = "unix_ms" }
 # Optional label rules (default = []):
 # 1) Dynamic field label:
 #    { field = "device_id", label = "device" }
@@ -45,43 +45,43 @@ timestamp = { field = "event_time", format = "unix_ms" }
 # 3) MQTT v5 property label:
 #    { property = "content_type", label = "mime" }
 #    { property = "tenant", label = "tenant" }  # MQTT v5 user property
-labels = [
-  { field = "device_id", label = "device" },
-  { field = "site", label = "site" },
-  { static = { source = "mqtt" } },
-  { property = "content_type", label = "mime" },
-  { property = "tenant", label = "tenant" }
-]
+#labels = [
+#  { field = "device_id", label = "device" },
+#  { field = "site", label = "site" },
+#  { static = { source = "mqtt" } },
+#  { property = "content_type", label = "mime" },
+#  { property = "tenant", label = "tenant" }
+#]
 
-[[inputs.mqtt.main.topics]]
-name = "factory/+/events"
-# MQTT v5 user properties can also be used as timestamp sources.
-# timestamp = { property = "event_time", format = "unix_us" }
-labels = [
-  { static = { source = "mqtt-events" } }
-]
+#[[inputs.mqtt.main.topics]]
+#name = "factory/+/events"
+## MQTT v5 user properties can also be used as timestamp sources.
+## timestamp = { property = "event_time", format = "unix_us" }
+#labels = [
+#  { static = { source = "mqtt-events" } }
+#]
 
 
-# MQTT v3 input configuration.
-[inputs.mqtt.legacy]
-broker = "mqtt://broker.example.com:1883"
-client_id = "reduct-bridge-legacy"
-version = "v3"
-qos = 0
-
-username = "legacy_user"
-password = "${LEGACY_MQTT_PASSWORD}"
-
-entry_prefix = "/mqtt"
-
-[[inputs.mqtt.legacy.topics]]
-name = "legacy/+/data"
-entry_name = "legacy"
-content_type = "application/json"
-labels = [
-  { field = "line", label = "line" },
-  { static = { source = "mqtt-v3" } }
-]
+## MQTT v3 input configuration.
+#[inputs.mqtt.legacy]
+#broker = "mqtt://broker.example.com:1883"
+#client_id = "reduct-bridge-legacy"
+#version = "v3"
+#qos = 0
+#
+#username = "legacy_user"
+#password = "${LEGACY_MQTT_PASSWORD}"
+#
+#entry_prefix = "/mqtt"
+#
+#[[inputs.mqtt.legacy.topics]]
+#name = "legacy/+/data"
+#entry_name = "legacy"
+#content_type = "application/json"
+#labels = [
+#  { field = "line", label = "line" },
+#  { static = { source = "mqtt-v3" } }
+#]
 
 
 # Pipelines
@@ -89,6 +89,6 @@ labels = [
 remote = "local"
 inputs = ["main"]
 
-[pipelines.mqtt_v3_pipeline]
-remote = "local"
-inputs = ["legacy"]
+#[pipelines.mqtt_v3_pipeline]
+#remote = "local"
+#inputs = ["legacy"]

--- a/examples/mqtt_config.toml
+++ b/examples/mqtt_config.toml
@@ -34,6 +34,9 @@ entry_prefix = "/mqtt"
 name = "factory/+/telemetry"
 entry_name = "telemetry"
 content_type = "application/json"
+# Optional timestamp mapping from a payload field. If extraction fails, ingest time is used.
+# Supported formats: unix_s, unix_ms, unix_us, unix_ns, iso8601, ros_stamp.
+timestamp = { field = "event_time", format = "unix_ms" }
 # Optional label rules (default = []):
 # 1) Dynamic field label:
 #    { field = "device_id", label = "device" }
@@ -52,6 +55,8 @@ labels = [
 
 [[inputs.mqtt.main.topics]]
 name = "factory/+/events"
+# MQTT v5 user properties can also be used as timestamp sources.
+# timestamp = { property = "event_time", format = "unix_us" }
 labels = [
   { static = { source = "mqtt-events" } }
 ]

--- a/src/input/http/README.md
+++ b/src/input/http/README.md
@@ -24,6 +24,11 @@ entry_name = "http/metrics"
 # If omitted, the response Content-Type header is used when available.
 content_type = "application/json"
 
+# Optional timestamp mapping. If extraction fails, ingest time is used.
+# Use either a JSON field or a response header.
+timestamp = { field = "metadata.timestamp", format = "unix_ms" }
+# timestamp = { header = "x-event-time", format = "iso8601" }
+
 # Optional bearer token authentication.
 bearer_token = "${HTTP_TOKEN}"
 
@@ -72,6 +77,8 @@ password = "${HTTP_PASSWORD}"
 - Failed requests and non-success HTTP statuses skip that polling cycle.
 - `entry_name` cannot be empty.
 - `repeat_interval` must be greater than zero.
+
+**Performance:** Configuring `timestamp = { field = "..." }` enables payload decoding for each message, which may increase CPU usage. If you already use field-based label rules, no additional cost is incurred since the decoded payload is shared.
 
 ## Build
 

--- a/src/input/http/mod.rs
+++ b/src/input/http/mod.rs
@@ -16,6 +16,7 @@ use crate::formats::{DecodeFormat, FormatHandler, PayloadFormatHandler};
 use crate::input::InputLauncher;
 use crate::message::{Message, Record};
 use crate::runtime::ComponentRuntime;
+use crate::timestamp::{TimestampMapping, resolve_from_json, resolve_from_string};
 use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -43,6 +44,8 @@ pub struct HttpConfig {
     pub basic_auth: Option<HttpBasicAuthConfig>,
     #[serde(default)]
     pub labels: Vec<HttpLabelRule>,
+    #[serde(default)]
+    pub timestamp: Option<TimestampMapping>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -70,10 +73,14 @@ impl HttpInstance {
         Self { cfg }
     }
 
-    fn needs_body_decode(rules: &[HttpLabelRule]) -> bool {
-        rules
+    fn needs_body_decode(cfg: &HttpConfig) -> bool {
+        cfg.labels
             .iter()
             .any(|rule| matches!(rule, HttpLabelRule::Field { .. }))
+            || cfg
+                .timestamp
+                .as_ref()
+                .is_some_and(TimestampMapping::has_field)
     }
 
     fn validate_config(cfg: &HttpConfig) -> Result<()> {
@@ -109,6 +116,44 @@ impl HttpInstance {
                 bail!("HTTP input basic_auth.password must not be empty");
             }
         }
+        Self::validate_timestamp_mapping(cfg)?;
+        Ok(())
+    }
+
+    fn validate_timestamp_mapping(cfg: &HttpConfig) -> Result<()> {
+        let Some(timestamp) = &cfg.timestamp else {
+            return Ok(());
+        };
+
+        if timestamp.source_count() != 1 {
+            bail!("HTTP input timestamp must define exactly one of 'field' or 'header'");
+        }
+        if timestamp.property.is_some() {
+            bail!("HTTP input timestamp.property is not supported");
+        }
+        if timestamp
+            .field
+            .as_ref()
+            .is_some_and(|field| field.trim().is_empty())
+        {
+            bail!("HTTP input timestamp.field must not be empty");
+        }
+        if timestamp
+            .header
+            .as_ref()
+            .is_some_and(|header| header.trim().is_empty())
+        {
+            bail!("HTTP input timestamp.header must not be empty");
+        }
+        if timestamp.field.is_some()
+            && cfg
+                .content_type
+                .as_ref()
+                .is_some_and(|content_type| !is_json_content_type(content_type))
+        {
+            bail!("HTTP input timestamp.field requires JSON content_type");
+        }
+
         Ok(())
     }
 
@@ -149,7 +194,7 @@ impl HttpInstance {
         cfg: &'a HttpConfig,
         headers: &'a HeaderMap,
     ) -> Option<DecodeFormat<'a>> {
-        if !Self::needs_body_decode(&cfg.labels) {
+        if !Self::needs_body_decode(cfg) {
             return None;
         }
 
@@ -182,6 +227,28 @@ impl HttpInstance {
         })
     }
 
+    fn resolve_timestamp(
+        headers: &HeaderMap,
+        decoded_payload: Option<&Value>,
+        cfg: &HttpConfig,
+    ) -> Option<u64> {
+        let timestamp = cfg.timestamp.as_ref()?;
+
+        if let Some(field) = timestamp.field.as_deref() {
+            return decoded_payload
+                .and_then(|payload| resolve_from_json(payload, field, &timestamp.format));
+        }
+
+        if let Some(header) = timestamp.header.as_deref() {
+            return headers
+                .get(header)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| resolve_from_string(value, &timestamp.format));
+        }
+
+        None
+    }
+
     async fn poll_once(client: &reqwest::Client, cfg: &HttpConfig) -> Result<Record> {
         let response = build_request(client, cfg)
             .send()
@@ -200,7 +267,8 @@ impl HttpInstance {
             .await
             .map_err(|err| anyhow::anyhow!("Failed to read HTTP response body: {}", err))?;
         let decoded_payload = Self::decode_payload_for_labels(cfg, &headers, &content, &format);
-        let timestamp_us = current_timestamp_us();
+        let timestamp_us = Self::resolve_timestamp(&headers, decoded_payload.as_ref(), cfg)
+            .unwrap_or_else(current_timestamp_us);
 
         Ok(Record {
             timestamp_us,
@@ -274,6 +342,14 @@ fn current_timestamp_us() -> u64 {
         .as_micros() as u64
 }
 
+fn is_json_content_type(content_type: &str) -> bool {
+    let Some(media_type) = content_type.split(';').next() else {
+        return false;
+    };
+    let media_type = media_type.trim().to_ascii_lowercase();
+    media_type == "application/json" || media_type.ends_with("+json")
+}
+
 fn create_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .build()
@@ -298,6 +374,7 @@ mod tests {
     use crate::formats::DecodeFormat;
     use crate::input::InputLauncher;
     use crate::message::Message;
+    use crate::timestamp::{TimestampFormat, TimestampMapping};
     use reqwest::header::{CONTENT_TYPE, ETAG, HeaderMap, HeaderValue};
     use rstest::{fixture, rstest};
     use serde_json::json;
@@ -329,6 +406,7 @@ mod tests {
             bearer_token: None,
             basic_auth: None,
             labels: Vec::new(),
+            timestamp: None,
         }
     }
 
@@ -377,6 +455,7 @@ mod tests {
         assert_eq!(cfg.entry_name, "http/data");
         assert!(cfg.content_type.is_none());
         assert!(cfg.labels.is_empty());
+        assert!(cfg.timestamp.is_none());
     }
 
     #[rstest]
@@ -514,6 +593,56 @@ mod tests {
             .to_string();
 
         assert!(err.contains(expected_error));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn poll_once_uses_json_field_timestamp(mut http_cfg: HttpConfig) {
+        let server = spawn_server(|_request| {
+            let body = r#"{"metadata":{"timestamp":1500}}"#;
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+        });
+        http_cfg.url = format!("http://{}/metrics", server.address);
+        http_cfg.timestamp = Some(TimestampMapping {
+            field: Some("metadata.timestamp".to_string()),
+            property: None,
+            header: None,
+            format: TimestampFormat::UnixMs,
+        });
+
+        let record = HttpInstance::poll_once(&create_client().unwrap(), &http_cfg)
+            .await
+            .unwrap();
+
+        assert_eq!(record.timestamp_us, 1_500_000);
+        server.join();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn poll_once_uses_response_header_timestamp(mut http_cfg: HttpConfig) {
+        let server = spawn_server(|_request| {
+            "HTTP/1.1 200 OK\r\nX-Event-Time: 1970-01-01T00:00:01.500Z\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}"
+                .to_string()
+        });
+        http_cfg.url = format!("http://{}/metrics", server.address);
+        http_cfg.timestamp = Some(TimestampMapping {
+            field: None,
+            property: None,
+            header: Some("x-event-time".to_string()),
+            format: TimestampFormat::Iso8601,
+        });
+
+        let record = HttpInstance::poll_once(&create_client().unwrap(), &http_cfg)
+            .await
+            .unwrap();
+
+        assert_eq!(record.timestamp_us, 1_500_000);
+        server.join();
     }
 
     #[rstest]

--- a/src/input/http/mod.rs
+++ b/src/input/http/mod.rs
@@ -16,7 +16,10 @@ use crate::formats::{DecodeFormat, FormatHandler, PayloadFormatHandler};
 use crate::input::InputLauncher;
 use crate::message::{Message, Record};
 use crate::runtime::ComponentRuntime;
-use crate::timestamp::{TimestampMapping, resolve_from_json, resolve_from_string};
+use crate::timestamp::{
+    TimeResolutionError, TimeResolutionResult, TimestampMapping, resolve_from_json,
+    resolve_from_string,
+};
 use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
 use log::{debug, info, warn};
@@ -231,19 +234,35 @@ impl HttpInstance {
         headers: &HeaderMap,
         decoded_payload: Option<&Value>,
         cfg: &HttpConfig,
-    ) -> Option<u64> {
+    ) -> Option<TimeResolutionResult> {
         let timestamp = cfg.timestamp.as_ref()?;
 
         if let Some(field) = timestamp.field.as_deref() {
-            return decoded_payload
-                .and_then(|payload| resolve_from_json(payload, field, &timestamp.format));
+            return Some(
+                decoded_payload
+                    .map(|payload| resolve_from_json(payload, field, &timestamp.format))
+                    .unwrap_or_else(|| Err(TimeResolutionError::resolution_failed("field", field))),
+            );
         }
 
         if let Some(header) = timestamp.header.as_deref() {
-            return headers
-                .get(header)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|value| resolve_from_string(value, &timestamp.format));
+            let Some(value) = headers.get(header) else {
+                return Some(Err(TimeResolutionError::resolution_failed(
+                    "header", header,
+                )));
+            };
+            return Some(
+                value
+                    .to_str()
+                    .map(|value| resolve_from_string(value, "header", header, &timestamp.format))
+                    .unwrap_or_else(|_| {
+                        Err(TimeResolutionError::parsing_failed(
+                            "header",
+                            header,
+                            &timestamp.format,
+                        ))
+                    }),
+            );
         }
 
         None
@@ -267,8 +286,17 @@ impl HttpInstance {
             .await
             .map_err(|err| anyhow::anyhow!("Failed to read HTTP response body: {}", err))?;
         let decoded_payload = Self::decode_payload_for_labels(cfg, &headers, &content, &format);
-        let timestamp_us = Self::resolve_timestamp(&headers, decoded_payload.as_ref(), cfg)
-            .unwrap_or_else(current_timestamp_us);
+        let timestamp_us = match Self::resolve_timestamp(&headers, decoded_payload.as_ref(), cfg) {
+            Some(Ok(timestamp_us)) => timestamp_us,
+            Some(Err(err)) => {
+                warn!(
+                    "HTTP timestamp mapping failed for '{}': {}; using ingest time",
+                    cfg.url, err
+                );
+                current_timestamp_us()
+            }
+            None => current_timestamp_us(),
+        };
 
         Ok(Record {
             timestamp_us,

--- a/src/input/mqtt/README.md
+++ b/src/input/mqtt/README.md
@@ -13,6 +13,15 @@ Labels are applied with the following rules:
   - `property = "content_type"` reads the built-in MQTT v5 `content_type` property.
   - `property = "<name>"` reads the MQTT v5 user property named `<name>`.
 
+Record timestamps can be mapped per topic with `timestamp`:
+
+- `timestamp = { field = "event_time", format = "unix_ms" }` reads from a JSON or schema-decoded protobuf payload field.
+- `timestamp = { property = "event_time", format = "unix_us" }` reads from an MQTT v5 user property.
+- Supported formats are `unix_s`, `unix_ms`, `unix_us`, `unix_ns`, `iso8601`, and `ros_stamp`.
+- If timestamp extraction fails, the input falls back to the ingest time.
+
+**Performance:** Configuring `timestamp = { field = "..." }` enables payload decoding for each message, which may increase CPU usage. If you already use field-based label rules, no additional cost is incurred since the decoded payload is shared.
+
 ## Protobuf support
 
 MQTT input supports protobuf payloads and can map protobuf fields to labels.
@@ -61,6 +70,7 @@ entry_prefix = "/mqtt"
 name = "factory/+/telemetry"
 entry_name = "telemetry"
 content_type = "application/json"
+timestamp = { field = "event_time", format = "unix_ms" }
 labels = [
   { field = "device_id", label = "device" },
   { field = "site", label = "site" },

--- a/src/input/mqtt/mod.rs
+++ b/src/input/mqtt/mod.rs
@@ -22,7 +22,10 @@ use crate::formats::{
 use crate::input::InputLauncher;
 use crate::message::{Attachment, Message};
 use crate::runtime::ComponentRuntime;
-use crate::timestamp::{TimestampMapping, resolve_from_json, resolve_from_string};
+use crate::timestamp::{
+    TimeResolutionError, TimeResolutionResult, TimestampMapping, resolve_from_json,
+    resolve_from_string,
+};
 use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
 use log::{info, warn};
@@ -607,18 +610,26 @@ pub(super) fn resolve_record_timestamp(
     topic_cfg: &MqttTopicConfig,
     decoded_payload: Option<&Value>,
     property_resolver: Option<&dyn PropertyLabelResolver>,
-) -> Option<u64> {
+) -> Option<TimeResolutionResult> {
     let timestamp = topic_cfg.timestamp.as_ref()?;
 
     if let Some(field) = timestamp.field.as_deref() {
-        return decoded_payload
-            .and_then(|payload| resolve_from_json(payload, field, &timestamp.format));
+        return Some(
+            decoded_payload
+                .map(|payload| resolve_from_json(payload, field, &timestamp.format))
+                .unwrap_or_else(|| Err(TimeResolutionError::resolution_failed("field", field))),
+        );
     }
 
     if let Some(property) = timestamp.property.as_deref() {
-        return property_resolver
-            .and_then(|resolver| resolver.resolve_property(property))
-            .and_then(|value| resolve_from_string(&value, &timestamp.format));
+        return Some(
+            property_resolver
+                .and_then(|resolver| resolver.resolve_property(property))
+                .map(|value| resolve_from_string(&value, "property", property, &timestamp.format))
+                .unwrap_or_else(|| {
+                    Err(TimeResolutionError::resolution_failed("property", property))
+                }),
+        );
     }
 
     None

--- a/src/input/mqtt/mod.rs
+++ b/src/input/mqtt/mod.rs
@@ -22,6 +22,7 @@ use crate::formats::{
 use crate::input::InputLauncher;
 use crate::message::{Attachment, Message};
 use crate::runtime::ComponentRuntime;
+use crate::timestamp::{TimestampMapping, resolve_from_json, resolve_from_string};
 use anyhow::{Error, Result, bail};
 use async_trait::async_trait;
 use log::{info, warn};
@@ -72,6 +73,8 @@ pub struct MqttTopicConfig {
     pub schema_name: Option<String>,
     #[serde(default)]
     pub labels: Vec<MqttLabelRule>,
+    #[serde(default)]
+    pub timestamp: Option<TimestampMapping>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -163,6 +166,14 @@ impl MqttInstance {
             {
                 bail!("MQTT v3 input does not support property label rules");
             }
+            if matches!(cfg.version, MqttVersion::V3)
+                && topic
+                    .timestamp
+                    .as_ref()
+                    .is_some_and(|timestamp| timestamp.property.is_some())
+            {
+                bail!("MQTT v3 input does not support timestamp property mapping");
+            }
             if topic.schema_path.is_some() != topic.schema_name.is_some() {
                 bail!(
                     "MQTT topic '{}': schema_path and schema_name must both be set or both omitted",
@@ -170,6 +181,7 @@ impl MqttInstance {
                 );
             }
             let payload_format = payload_format_for_topic(topic);
+            Self::validate_timestamp_mapping(&topic.name, topic, payload_format)?;
             Self::validate_topic_payload_format(&topic.name, topic, payload_format)?;
             for rule in &topic.labels {
                 Self::validate_field_label_rule(&topic.name, rule)?;
@@ -188,6 +200,72 @@ impl MqttInstance {
 
         if cfg.password.is_some() && cfg.username.is_none() {
             bail!("MQTT input password requires username to be set");
+        }
+
+        Ok(())
+    }
+
+    fn validate_timestamp_mapping(
+        topic_name: &str,
+        topic: &MqttTopicConfig,
+        payload_format: PayloadFormat,
+    ) -> Result<()> {
+        let Some(timestamp) = &topic.timestamp else {
+            return Ok(());
+        };
+
+        if timestamp.source_count() != 1 {
+            bail!(
+                "MQTT topic '{}': timestamp must define exactly one of 'field' or 'property'",
+                topic_name
+            );
+        }
+        if timestamp.header.is_some() {
+            bail!(
+                "MQTT topic '{}': timestamp.header is not supported",
+                topic_name
+            );
+        }
+        if timestamp
+            .field
+            .as_ref()
+            .is_some_and(|field| field.trim().is_empty())
+        {
+            bail!(
+                "MQTT topic '{}': timestamp.field must not be empty",
+                topic_name
+            );
+        }
+        if timestamp
+            .property
+            .as_ref()
+            .is_some_and(|property| property.trim().is_empty())
+        {
+            bail!(
+                "MQTT topic '{}': timestamp.property must not be empty",
+                topic_name
+            );
+        }
+        if timestamp.property.as_deref() == Some("content_type") {
+            bail!(
+                "MQTT topic '{}': timestamp.property must reference an MQTT v5 user property",
+                topic_name
+            );
+        }
+
+        if timestamp.field.is_some() {
+            match payload_format {
+                PayloadFormat::Json => {}
+                PayloadFormat::Protobuf if topic.schema_path.is_some() => {}
+                PayloadFormat::Protobuf => bail!(
+                    "MQTT topic '{}': protobuf timestamp.field requires schema_path/schema_name",
+                    topic_name
+                ),
+                PayloadFormat::None => bail!(
+                    "MQTT topic '{}': timestamp.field requires JSON or protobuf content_type",
+                    topic_name
+                ),
+            }
         }
 
         Ok(())
@@ -334,6 +412,17 @@ fn topic_uses_decode_labels(topic: &MqttTopicConfig) -> bool {
         .any(|rule| matches!(rule, MqttLabelRule::Field { .. }))
 }
 
+fn topic_uses_decoded_payload(topic: &MqttTopicConfig) -> bool {
+    topic
+        .labels
+        .iter()
+        .any(|rule| matches!(rule, MqttLabelRule::Field { field: Some(_), .. }))
+        || topic
+            .timestamp
+            .as_ref()
+            .is_some_and(TimestampMapping::has_field)
+}
+
 pub(super) fn current_timestamp_us() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -446,15 +535,31 @@ pub(super) fn build_record_labels(
     property_resolver: Option<&dyn PropertyLabelResolver>,
     format: &dyn FormatHandler,
 ) -> HashMap<String, String> {
-    let mut labels = HashMap::new();
+    let decoded_payload = decode_payload_for_record(topic_cfg, payload, format);
 
-    let decoded_payload = decode_payload_for_labels(topic_cfg, payload, format);
+    build_record_labels_with_decoded(
+        topic_cfg,
+        payload,
+        decoded_payload.as_ref(),
+        property_resolver,
+        format,
+    )
+}
+
+pub(super) fn build_record_labels_with_decoded(
+    topic_cfg: &MqttTopicConfig,
+    payload: &[u8],
+    decoded_payload: Option<&Value>,
+    property_resolver: Option<&dyn PropertyLabelResolver>,
+    format: &dyn FormatHandler,
+) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
 
     for rule in &topic_cfg.labels {
         apply_label_rule(
             &mut labels,
             rule,
-            decoded_payload.as_ref(),
+            decoded_payload,
             payload,
             property_resolver,
             format,
@@ -468,11 +573,15 @@ pub(super) trait PropertyLabelResolver {
     fn resolve_property(&self, property_name: &str) -> Option<String>;
 }
 
-fn decode_payload_for_labels(
+pub(super) fn decode_payload_for_record(
     topic_cfg: &MqttTopicConfig,
     payload: &[u8],
     format: &dyn FormatHandler,
 ) -> Option<Value> {
+    if !topic_uses_decoded_payload(topic_cfg) {
+        return None;
+    }
+
     match payload_format_for_topic(topic_cfg) {
         PayloadFormat::Json => format.decode_payload(payload, DecodeFormat::Json),
         PayloadFormat::Protobuf => {
@@ -492,6 +601,27 @@ fn decode_payload_for_labels(
         }
         PayloadFormat::None => None,
     }
+}
+
+pub(super) fn resolve_record_timestamp(
+    topic_cfg: &MqttTopicConfig,
+    decoded_payload: Option<&Value>,
+    property_resolver: Option<&dyn PropertyLabelResolver>,
+) -> Option<u64> {
+    let timestamp = topic_cfg.timestamp.as_ref()?;
+
+    if let Some(field) = timestamp.field.as_deref() {
+        return decoded_payload
+            .and_then(|payload| resolve_from_json(payload, field, &timestamp.format));
+    }
+
+    if let Some(property) = timestamp.property.as_deref() {
+        return property_resolver
+            .and_then(|resolver| resolver.resolve_property(property))
+            .and_then(|value| resolve_from_string(&value, &timestamp.format));
+    }
+
+    None
 }
 
 fn apply_label_rule(
@@ -667,6 +797,7 @@ mod tests {
     };
     use crate::formats::PayloadFormatHandler;
     use crate::formats::protobuf::ProtobufHandler;
+    use crate::timestamp::{TimestampFormat, TimestampMapping};
     use bytes::Bytes;
     use rstest::{fixture, rstest};
     use rumqttc::v5::mqttbytes::v5::{Publish as V5Publish, PublishProperties};
@@ -685,6 +816,7 @@ mod tests {
                 schema_path: None,
                 schema_name: None,
                 labels: Vec::new(),
+                timestamp: None,
             }],
             qos: 1,
             username: None,
@@ -729,6 +861,25 @@ mod tests {
         cfg.topics[0].content_type = Some(" ".to_string());
     }
 
+    fn add_v3_timestamp_property(cfg: &mut MqttConfig) {
+        cfg.version = MqttVersion::V3;
+        cfg.topics[0].timestamp = Some(TimestampMapping {
+            field: None,
+            property: Some("event_time".to_string()),
+            header: None,
+            format: TimestampFormat::UnixUs,
+        });
+    }
+
+    fn add_timestamp_field_without_content_type(cfg: &mut MqttConfig) {
+        cfg.topics[0].timestamp = Some(TimestampMapping {
+            field: Some("event_time".to_string()),
+            property: None,
+            header: None,
+            format: TimestampFormat::UnixUs,
+        });
+    }
+
     #[test]
     fn rejects_labels_nested_under_topic_table() {
         let cfg_text = r#"
@@ -753,6 +904,14 @@ mod tests {
     #[case::invalid_qos(set_invalid_qos, "qos must be 0, 1, or 2")]
     #[case::password_without_username(set_password_without_username, "password requires username")]
     #[case::property_rule_for_v3(add_v3_property_rule, "does not support property label rules")]
+    #[case::timestamp_property_for_v3(
+        add_v3_timestamp_property,
+        "does not support timestamp property mapping"
+    )]
+    #[case::timestamp_field_without_content_type(
+        add_timestamp_field_without_content_type,
+        "timestamp.field requires JSON or protobuf content_type"
+    )]
     #[case::empty_topic_entry_name(
         set_empty_topic_entry_name,
         "topic entry_name must not be empty"
@@ -808,6 +967,7 @@ mod tests {
                     schema_path: None,
                     schema_name: None,
                     labels: Vec::new(),
+                    timestamp: None,
                 },
                 MqttTopicConfig {
                     name: "factory/+/telemetry".to_string(),
@@ -816,6 +976,7 @@ mod tests {
                     schema_path: None,
                     schema_name: None,
                     labels: Vec::new(),
+                    timestamp: None,
                 },
             ],
             ..mqtt_cfg()
@@ -836,6 +997,7 @@ mod tests {
             schema_path: None,
             schema_name: None,
             labels: Vec::new(),
+            timestamp: None,
         };
 
         assert_eq!(
@@ -1023,6 +1185,7 @@ mod tests {
             schema_path: None,
             schema_name: None,
             labels: Vec::new(),
+            timestamp: None,
         }];
         cfg.entry_prefix = "/mqtt".to_string();
         cfg.topics[0].labels = vec![
@@ -1056,6 +1219,33 @@ mod tests {
         assert_eq!(record.content_type, Some("application/json".to_string()));
         assert_eq!(record.labels.get("device"), Some(&"dev-1".to_string()));
         assert_eq!(record.labels.get("source"), Some(&"mqtt".to_string()));
+    }
+
+    #[test]
+    fn builds_v3_record_with_json_field_timestamp() {
+        let mut cfg = mqtt_cfg();
+        cfg.version = MqttVersion::V3;
+        cfg.topics[0].name = "factory/+".to_string();
+        cfg.topics[0].content_type = Some("application/json".to_string());
+        cfg.topics[0].timestamp = Some(TimestampMapping {
+            field: Some("event_time".to_string()),
+            property: None,
+            header: None,
+            format: TimestampFormat::UnixMs,
+        });
+
+        let publish = rumqttc::Publish {
+            dup: false,
+            qos: rumqttc::QoS::AtMostOnce,
+            retain: false,
+            topic: "factory/device-1".to_string(),
+            pkid: 0,
+            payload: Bytes::from_static(br#"{"event_time":1500}"#),
+        };
+
+        let record = mqtt3::build_v3_record(&cfg, &publish, &PayloadFormatHandler::new(None));
+
+        assert_eq!(record.timestamp_us, 1_500_000);
     }
 
     #[test]
@@ -1197,6 +1387,7 @@ mod tests {
             schema_path: None,
             schema_name: None,
             labels: Vec::new(),
+            timestamp: None,
         }];
         cfg.entry_prefix = "/mqtt".to_string();
         cfg.topics[0].labels = vec![
@@ -1248,6 +1439,32 @@ mod tests {
     }
 
     #[test]
+    fn builds_v5_record_with_user_property_timestamp() {
+        let mut cfg = mqtt_cfg();
+        cfg.topics[0].name = "factory/+".to_string();
+        cfg.topics[0].timestamp = Some(TimestampMapping {
+            field: None,
+            property: Some("event_time".to_string()),
+            header: None,
+            format: TimestampFormat::UnixUs,
+        });
+
+        let publish = V5Publish {
+            topic: Bytes::from_static(b"factory/device-9"),
+            payload: Bytes::from_static(b"{}"),
+            properties: Some(PublishProperties {
+                user_properties: vec![("event_time".to_string(), "1500000".to_string())],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let record = mqtt5::build_v5_record(&cfg, &publish, &PayloadFormatHandler::new(None));
+
+        assert_eq!(record.timestamp_us, 1_500_000);
+    }
+
+    #[test]
     fn uses_default_content_type_for_v5_when_property_is_missing() {
         let mut cfg = mqtt_cfg();
         cfg.topics = vec![MqttTopicConfig {
@@ -1257,6 +1474,7 @@ mod tests {
             schema_path: None,
             schema_name: None,
             labels: Vec::new(),
+            timestamp: None,
         }];
 
         let publish = V5Publish {

--- a/src/input/mqtt/mqtt3.rs
+++ b/src/input/mqtt/mqtt3.rs
@@ -1,7 +1,7 @@
 use super::{
-    BrokerScheme, MqttConfig, ParsedBroker, build_record_labels, current_timestamp_us,
-    emit_attachment, ensure_rustls_crypto_provider, find_topic_config, reconnect_retry_delay,
-    resolve_entry_name,
+    BrokerScheme, MqttConfig, ParsedBroker, build_record_labels_with_decoded, current_timestamp_us,
+    decode_payload_for_record, emit_attachment, ensure_rustls_crypto_provider, find_topic_config,
+    reconnect_retry_delay, resolve_entry_name, resolve_record_timestamp,
 };
 use crate::formats::FormatHandler;
 use crate::message::{Message, Record};
@@ -48,13 +48,23 @@ pub(super) fn build_v3_record(
 ) -> Record {
     let topic_cfg = find_topic_config(cfg, &publish.topic)
         .expect("received MQTT v3 publish for unsubscribed topic");
+    let decoded_payload = decode_payload_for_record(topic_cfg, publish.payload.as_ref(), format);
+    let labels = build_record_labels_with_decoded(
+        topic_cfg,
+        publish.payload.as_ref(),
+        decoded_payload.as_ref(),
+        None,
+        format,
+    );
+    let timestamp_us = resolve_record_timestamp(topic_cfg, decoded_payload.as_ref(), None)
+        .unwrap_or_else(current_timestamp_us);
 
     Record {
-        timestamp_us: current_timestamp_us(),
+        timestamp_us,
         entry_name: resolve_entry_name(&cfg.entry_prefix, topic_cfg, &publish.topic),
         content: publish.payload.clone(),
         content_type: topic_cfg.content_type.clone(),
-        labels: build_record_labels(topic_cfg, publish.payload.as_ref(), None, format),
+        labels,
     }
 }
 

--- a/src/input/mqtt/mqtt3.rs
+++ b/src/input/mqtt/mqtt3.rs
@@ -56,8 +56,17 @@ pub(super) fn build_v3_record(
         None,
         format,
     );
-    let timestamp_us = resolve_record_timestamp(topic_cfg, decoded_payload.as_ref(), None)
-        .unwrap_or_else(current_timestamp_us);
+    let timestamp_us = match resolve_record_timestamp(topic_cfg, decoded_payload.as_ref(), None) {
+        Some(Ok(timestamp_us)) => timestamp_us,
+        Some(Err(err)) => {
+            warn!(
+                "MQTT timestamp mapping failed for topic '{}': {}; using ingest time",
+                publish.topic, err
+            );
+            current_timestamp_us()
+        }
+        None => current_timestamp_us(),
+    };
 
     Record {
         timestamp_us,

--- a/src/input/mqtt/mqtt5.rs
+++ b/src/input/mqtt/mqtt5.rs
@@ -1,7 +1,8 @@
 use super::{
-    BrokerScheme, MqttConfig, ParsedBroker, PropertyLabelResolver, build_record_labels,
-    current_timestamp_us, emit_attachment, ensure_rustls_crypto_provider, find_topic_config,
-    reconnect_retry_delay, resolve_entry_name,
+    BrokerScheme, MqttConfig, ParsedBroker, PropertyLabelResolver,
+    build_record_labels_with_decoded, current_timestamp_us, decode_payload_for_record,
+    emit_attachment, ensure_rustls_crypto_provider, find_topic_config, reconnect_retry_delay,
+    resolve_entry_name, resolve_record_timestamp,
 };
 use crate::formats::FormatHandler;
 use crate::message::{Message, Record};
@@ -80,9 +81,23 @@ pub(super) fn build_v5_record(
     let topic_cfg = find_topic_config(cfg, &publish_topic)
         .expect("received MQTT v5 publish for unsubscribed topic");
     let property_resolver = V5PropertyResolver::new(publish);
+    let decoded_payload = decode_payload_for_record(topic_cfg, publish.payload.as_ref(), format);
+    let labels = build_record_labels_with_decoded(
+        topic_cfg,
+        publish.payload.as_ref(),
+        decoded_payload.as_ref(),
+        Some(&property_resolver),
+        format,
+    );
+    let timestamp_us = resolve_record_timestamp(
+        topic_cfg,
+        decoded_payload.as_ref(),
+        Some(&property_resolver),
+    )
+    .unwrap_or_else(current_timestamp_us);
 
     Record {
-        timestamp_us: current_timestamp_us(),
+        timestamp_us,
         entry_name: resolve_entry_name(&cfg.entry_prefix, topic_cfg, &publish_topic),
         content: publish.payload.clone(),
         content_type: publish
@@ -90,12 +105,7 @@ pub(super) fn build_v5_record(
             .as_ref()
             .and_then(|props| props.content_type.clone())
             .or_else(|| topic_cfg.content_type.clone()),
-        labels: build_record_labels(
-            topic_cfg,
-            publish.payload.as_ref(),
-            Some(&property_resolver),
-            format,
-        ),
+        labels,
     }
 }
 

--- a/src/input/mqtt/mqtt5.rs
+++ b/src/input/mqtt/mqtt5.rs
@@ -89,12 +89,21 @@ pub(super) fn build_v5_record(
         Some(&property_resolver),
         format,
     );
-    let timestamp_us = resolve_record_timestamp(
+    let timestamp_us = match resolve_record_timestamp(
         topic_cfg,
         decoded_payload.as_ref(),
         Some(&property_resolver),
-    )
-    .unwrap_or_else(current_timestamp_us);
+    ) {
+        Some(Ok(timestamp_us)) => timestamp_us,
+        Some(Err(err)) => {
+            warn!(
+                "MQTT timestamp mapping failed for topic '{}': {}; using ingest time",
+                publish_topic, err
+            );
+            current_timestamp_us()
+        }
+        None => current_timestamp_us(),
+    };
 
     Record {
         timestamp_us,

--- a/src/input/ros1/README.md
+++ b/src/input/ros1/README.md
@@ -43,6 +43,10 @@ labels = [
   { field = "data", label = "message" },
   { static = { source = "ros1" } }
 ]
+
+# Optional timestamp mapping. If extraction fails, ingest time is used.
+# For standard ROS headers, use header.stamp with ros_stamp format.
+timestamp = { field = "header.stamp", format = "ros_stamp" }
 ```
 
 ## Build
@@ -58,6 +62,8 @@ cargo build --no-default-features --features ros1
 - Empty topic names are not allowed.
 - `entry_name` cannot be empty when explicitly set.
 - Message schema metadata is stored automatically for ROS topics.
+
+**Performance:** Configuring `timestamp = { field = "..." }` enables dynamic message decoding for each message, which may increase CPU usage. If you already use field-based label rules, no additional cost is incurred since the decoded payload is shared.
 
 ## Changes
 

--- a/src/input/ros1/instance.rs
+++ b/src/input/ros1/instance.rs
@@ -1,6 +1,6 @@
 use crate::formats::json::{extract_json_path, value_to_label};
 use crate::formats::ros1::msg_to_json;
-use crate::timestamp::{TimestampMapping, resolve_from_json};
+use crate::timestamp::{TimeResolutionResult, TimestampMapping, resolve_from_json};
 use anyhow::{Error, anyhow, bail};
 use log::warn;
 use rosrust::DynamicMsg;
@@ -101,11 +101,14 @@ impl Ros1Instance {
             .is_some_and(TimestampMapping::has_field)
     }
 
-    pub(super) fn resolve_timestamp(message: &Value, topic: &Ros1TopicConfig) -> Option<u64> {
+    pub(super) fn resolve_timestamp(
+        message: &Value,
+        topic: &Ros1TopicConfig,
+    ) -> Option<TimeResolutionResult> {
         let timestamp = topic.timestamp.as_ref()?;
         let field = timestamp.field.as_deref()?;
 
-        resolve_from_json(message, field, &timestamp.format)
+        Some(resolve_from_json(message, field, &timestamp.format))
     }
 
     pub(super) fn try_init_ros(node_name: &str, master_uri: &str) -> Result<(), Error> {
@@ -297,7 +300,7 @@ mod tests {
         assert!(Ros1Instance::has_timestamp_field(&topic));
         assert_eq!(
             Ros1Instance::resolve_timestamp(&message, &topic),
-            Some(42_123_456)
+            Some(Ok(42_123_456))
         );
     }
 

--- a/src/input/ros1/instance.rs
+++ b/src/input/ros1/instance.rs
@@ -1,5 +1,6 @@
 use crate::formats::json::{extract_json_path, value_to_label};
 use crate::formats::ros1::msg_to_json;
+use crate::timestamp::{TimestampMapping, resolve_from_json};
 use anyhow::{Error, anyhow, bail};
 use log::warn;
 use rosrust::DynamicMsg;
@@ -27,6 +28,8 @@ pub struct Ros1TopicConfig {
     pub entry_name: Option<String>,
     #[serde(default)]
     pub labels: Vec<Ros1LabelRule>,
+    #[serde(default)]
+    pub timestamp: Option<TimestampMapping>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -89,6 +92,20 @@ impl Ros1Instance {
         rules
             .iter()
             .any(|rule| matches!(rule, Ros1LabelRule::Field { .. }))
+    }
+
+    pub(super) fn has_timestamp_field(topic: &Ros1TopicConfig) -> bool {
+        topic
+            .timestamp
+            .as_ref()
+            .is_some_and(TimestampMapping::has_field)
+    }
+
+    pub(super) fn resolve_timestamp(message: &Value, topic: &Ros1TopicConfig) -> Option<u64> {
+        let timestamp = topic.timestamp.as_ref()?;
+        let field = timestamp.field.as_deref()?;
+
+        resolve_from_json(message, field, &timestamp.format)
     }
 
     pub(super) fn try_init_ros(node_name: &str, master_uri: &str) -> Result<(), Error> {
@@ -157,7 +174,8 @@ impl Ros1Instance {
 
 #[cfg(test)]
 mod tests {
-    use super::{PublisherDecoder, Ros1Instance, Ros1LabelRule};
+    use super::{PublisherDecoder, Ros1Instance, Ros1LabelRule, Ros1TopicConfig};
+    use crate::timestamp::{TimestampFormat, TimestampMapping};
     use rstest::{fixture, rstest};
     use serde_json::json;
     use std::collections::HashMap;
@@ -252,6 +270,35 @@ mod tests {
         #[case] expected: bool,
     ) {
         assert_eq!(Ros1Instance::has_dynamic_labels(&rules), expected);
+    }
+
+    #[test]
+    fn resolves_ros_stamp_timestamp_from_field() {
+        let topic = Ros1TopicConfig {
+            name: "/sensor/imu".to_string(),
+            entry_name: None,
+            labels: Vec::new(),
+            timestamp: Some(TimestampMapping {
+                field: Some("header.stamp".to_string()),
+                property: None,
+                header: None,
+                format: TimestampFormat::RosStamp,
+            }),
+        };
+        let message = json!({
+            "header": {
+                "stamp": {
+                    "sec": 42,
+                    "nsec": 123_456_789u64
+                }
+            }
+        });
+
+        assert!(Ros1Instance::has_timestamp_field(&topic));
+        assert_eq!(
+            Ros1Instance::resolve_timestamp(&message, &topic),
+            Some(42_123_456)
+        );
     }
 
     #[rstest]

--- a/src/input/ros1/mod.rs
+++ b/src/input/ros1/mod.rs
@@ -59,6 +59,7 @@ impl InputLauncher for Ros1Instance {
             {
                 bail!("ROS topic entry_name must not be empty");
             }
+            validate_timestamp_mapping(topic_cfg)?;
         }
 
         let subscribers = tokio::task::spawn_blocking({
@@ -82,12 +83,13 @@ impl InputLauncher for Ros1Instance {
                         .entry_name
                         .clone()
                         .unwrap_or_else(|| topic_name.clone());
-                    let needs_dynamic_labels = Ros1Instance::has_dynamic_labels(&topic_cfg.labels);
+                    let needs_decode = Ros1Instance::has_dynamic_labels(&topic_cfg.labels)
+                        || Ros1Instance::has_timestamp_field(&topic_cfg);
                     let runtime = TopicRuntime::new(
                         topic_cfg.clone(),
                         topic_name.clone(),
                         entry_name,
-                        needs_dynamic_labels,
+                        needs_decode,
                         pipeline_tx.clone(),
                     );
 
@@ -151,4 +153,41 @@ impl InputLauncher for Ros1Instance {
 
         Ok(ComponentRuntime { tx, task })
     }
+}
+
+fn validate_timestamp_mapping(topic: &Ros1TopicConfig) -> Result<(), Error> {
+    let Some(timestamp) = &topic.timestamp else {
+        return Ok(());
+    };
+
+    if timestamp.source_count() != 1 {
+        bail!(
+            "ROS topic '{}' timestamp must define exactly one 'field'",
+            topic.name
+        );
+    }
+    if timestamp.property.is_some() {
+        bail!(
+            "ROS topic '{}' timestamp.property is not supported",
+            topic.name
+        );
+    }
+    if timestamp.header.is_some() {
+        bail!(
+            "ROS topic '{}' timestamp.header is not supported",
+            topic.name
+        );
+    }
+    if timestamp
+        .field
+        .as_ref()
+        .is_some_and(|field| field.trim().is_empty())
+    {
+        bail!(
+            "ROS topic '{}' timestamp.field must not be empty",
+            topic.name
+        );
+    }
+
+    Ok(())
 }

--- a/src/input/ros1/mod.rs
+++ b/src/input/ros1/mod.rs
@@ -191,3 +191,77 @@ fn validate_timestamp_mapping(topic: &Ros1TopicConfig) -> Result<(), Error> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::validate_timestamp_mapping;
+    use crate::input::ros1::instance::Ros1TopicConfig;
+    use crate::timestamp::{TimestampFormat, TimestampMapping};
+    use rstest::rstest;
+
+    fn topic_with_timestamp(timestamp: Option<TimestampMapping>) -> Ros1TopicConfig {
+        Ros1TopicConfig {
+            name: "/sensor/imu".to_string(),
+            entry_name: None,
+            labels: Vec::new(),
+            timestamp,
+        }
+    }
+
+    fn timestamp_mapping(
+        field: Option<&str>,
+        property: Option<&str>,
+        header: Option<&str>,
+    ) -> TimestampMapping {
+        TimestampMapping {
+            field: field.map(str::to_string),
+            property: property.map(str::to_string),
+            header: header.map(str::to_string),
+            format: TimestampFormat::RosStamp,
+        }
+    }
+
+    #[rstest]
+    #[case(None)]
+    #[case(Some(timestamp_mapping(Some("header.stamp"), None, None)))]
+    fn accepts_valid_timestamp_mapping(#[case] timestamp: Option<TimestampMapping>) {
+        let topic = topic_with_timestamp(timestamp);
+
+        validate_timestamp_mapping(&topic).expect("timestamp mapping should be valid");
+    }
+
+    #[rstest]
+    #[case(
+        timestamp_mapping(None, None, None),
+        "timestamp must define exactly one 'field'"
+    )]
+    #[case(
+        timestamp_mapping(Some("header.stamp"), Some("event_time"), None),
+        "timestamp must define exactly one 'field'"
+    )]
+    #[case(
+        timestamp_mapping(None, Some("event_time"), None),
+        "timestamp.property is not supported"
+    )]
+    #[case(
+        timestamp_mapping(None, None, Some("stamp")),
+        "timestamp.header is not supported"
+    )]
+    #[case(
+        timestamp_mapping(Some("   "), None, None),
+        "timestamp.field must not be empty"
+    )]
+    fn rejects_invalid_timestamp_mapping(
+        #[case] timestamp: TimestampMapping,
+        #[case] expected_error: &str,
+    ) {
+        let topic = topic_with_timestamp(Some(timestamp));
+
+        let err = validate_timestamp_mapping(&topic)
+            .expect_err("timestamp mapping should be invalid")
+            .to_string();
+
+        assert!(err.contains("/sensor/imu"));
+        assert!(err.contains(expected_error));
+    }
+}

--- a/src/input/ros1/topic_runtime.rs
+++ b/src/input/ros1/topic_runtime.rs
@@ -13,7 +13,7 @@ pub(super) struct TopicRuntime {
     topic_cfg: Ros1TopicConfig,
     topic_name: String,
     entry_name: String,
-    needs_dynamic_labels: bool,
+    needs_decode: bool,
     decoders: Arc<Mutex<HashMap<String, PublisherDecoder>>>,
     pipeline_tx: Sender<Message>,
 }
@@ -23,14 +23,14 @@ impl TopicRuntime {
         topic_cfg: Ros1TopicConfig,
         topic_name: String,
         entry_name: String,
-        needs_dynamic_labels: bool,
+        needs_decode: bool,
         pipeline_tx: Sender<Message>,
     ) -> Self {
         Self {
             topic_cfg,
             topic_name,
             entry_name,
-            needs_dynamic_labels,
+            needs_decode,
             decoders: Arc::new(Mutex::new(HashMap::new())),
             pipeline_tx,
         }
@@ -39,7 +39,7 @@ impl TopicRuntime {
     pub(super) fn handle_message(&self, raw: RawMessage, publisher_id: &str) {
         let msg_bytes = raw.0;
 
-        let decoded = if self.needs_dynamic_labels {
+        let decoded = if self.needs_decode {
             Ros1Instance::decode_for_labels(
                 &self.decoders,
                 &self.topic_name,
@@ -54,12 +54,13 @@ impl TopicRuntime {
             Some(value) => Ros1Instance::build_labels(value, &self.topic_cfg.labels),
             None => Ros1Instance::build_static_labels(&self.topic_cfg.labels),
         };
+        let timestamp_us = decoded
+            .as_ref()
+            .and_then(|value| Ros1Instance::resolve_timestamp(value, &self.topic_cfg))
+            .unwrap_or_else(current_timestamp_us);
 
         let record = Record {
-            timestamp_us: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_micros() as u64,
+            timestamp_us,
             entry_name: self.entry_name.clone(),
             content: msg_bytes.into(),
             content_type: Some(Ros1Instance::default_content_type().to_string()),
@@ -112,7 +113,7 @@ impl TopicRuntime {
             );
         }
 
-        if !self.needs_dynamic_labels {
+        if !self.needs_decode {
             return;
         }
 
@@ -141,6 +142,13 @@ impl TopicRuntime {
     }
 }
 
+fn current_timestamp_us() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
+}
+
 #[cfg(test)]
 mod tests {
     use super::TopicRuntime;
@@ -159,6 +167,7 @@ mod tests {
             labels: vec![Ros1LabelRule::Static {
                 r#static: HashMap::from([("source".to_string(), "ros1".to_string())]),
             }],
+            timestamp: None,
         }
     }
 

--- a/src/input/ros1/topic_runtime.rs
+++ b/src/input/ros1/topic_runtime.rs
@@ -1,6 +1,7 @@
 use super::instance::PublisherDecoder;
 use super::{Ros1Instance, Ros1TopicConfig};
 use crate::message::{Attachment, Message, Record};
+use crate::timestamp::TimeResolutionError;
 use log::warn;
 use rosrust::{DynamicMsg, RawMessage};
 use std::collections::HashMap;
@@ -54,10 +55,33 @@ impl TopicRuntime {
             Some(value) => Ros1Instance::build_labels(value, &self.topic_cfg.labels),
             None => Ros1Instance::build_static_labels(&self.topic_cfg.labels),
         };
-        let timestamp_us = decoded
-            .as_ref()
-            .and_then(|value| Ros1Instance::resolve_timestamp(value, &self.topic_cfg))
-            .unwrap_or_else(current_timestamp_us);
+        let timestamp_us = match decoded.as_ref() {
+            Some(value) => match Ros1Instance::resolve_timestamp(value, &self.topic_cfg) {
+                Some(Ok(timestamp_us)) => timestamp_us,
+                Some(Err(err)) => {
+                    warn!(
+                        "ROS timestamp mapping failed for topic '{}': {}; using ingest time",
+                        self.topic_name, err
+                    );
+                    current_timestamp_us()
+                }
+                None => current_timestamp_us(),
+            },
+            None => self
+                .topic_cfg
+                .timestamp
+                .as_ref()
+                .and_then(|timestamp| timestamp.field.as_deref())
+                .map(|field| TimeResolutionError::resolution_failed("field", field))
+                .map(|err| {
+                    warn!(
+                        "ROS timestamp mapping failed for topic '{}': {}; using ingest time",
+                        self.topic_name, err
+                    );
+                    current_timestamp_us()
+                })
+                .unwrap_or_else(current_timestamp_us),
+        };
 
         let record = Record {
             timestamp_us,

--- a/src/input/ros1/wildcard.rs
+++ b/src/input/ros1/wildcard.rs
@@ -129,6 +129,7 @@ mod tests {
             name: name.to_string(),
             entry_name: Some(entry_name.to_string()),
             labels: Vec::new(),
+            timestamp: None,
         }
     }
 

--- a/src/input/ros2/instance.rs
+++ b/src/input/ros2/instance.rs
@@ -3,6 +3,7 @@ use super::wildcard;
 use crate::formats::json::{extract_json_path, value_to_label};
 use crate::formats::ros2::Ros2DynamicParser;
 use crate::message::Message;
+use crate::timestamp::{TimeResolutionResult, TimestampFormat, resolve_from_json};
 use anyhow::{Error, anyhow, bail};
 use log::{info, warn};
 use rclrs::{
@@ -361,12 +362,8 @@ impl Ros2Instance {
         )
     }
 
-    pub(super) fn extract_header_timestamp_us(message: &Value) -> Option<u64> {
-        let header = message.get("header")?;
-        let stamp = header.get("stamp")?;
-        let sec = stamp.get("sec")?.as_u64()?;
-        let nanosec = stamp.get("nanosec")?.as_u64()?;
-        Some(sec * 1_000_000 + nanosec / 1_000)
+    pub(super) fn extract_header_timestamp_us(message: &Value) -> TimeResolutionResult {
+        resolve_from_json(message, "header.stamp", &TimestampFormat::RosStamp)
     }
 
     pub(super) fn message_info_timestamp_us(info: &MessageInfo) -> u64 {
@@ -675,7 +672,7 @@ mod tests {
     #[rstest]
     fn extract_header_timestamp_uses_ros_header_stamp(decoded_message: serde_json::Value) {
         let ts = Ros2Instance::extract_header_timestamp_us(&decoded_message);
-        assert_eq!(ts, Some(12_003_456));
+        assert_eq!(ts, Ok(12_003_456));
     }
 
     #[rstest]

--- a/src/input/ros2/topic_runtime.rs
+++ b/src/input/ros2/topic_runtime.rs
@@ -73,10 +73,20 @@ impl Ros2TopicRuntime {
             Some(message) => Ros2Instance::build_labels(message, &self.labels_cfg),
             None => Ros2Instance::build_static_labels(&self.labels_cfg),
         };
-        let timestamp_us = decoded
+        let timestamp_us = match decoded
             .as_ref()
-            .and_then(Ros2Instance::extract_header_timestamp_us)
-            .unwrap_or(fallback_timestamp_us);
+            .map(Ros2Instance::extract_header_timestamp_us)
+        {
+            Some(Ok(timestamp_us)) => timestamp_us,
+            Some(Err(err)) => {
+                warn!(
+                    "ROS2 timestamp mapping failed for topic '{}': {}; using fallback timestamp",
+                    self.topic_name, err
+                );
+                fallback_timestamp_us
+            }
+            None => fallback_timestamp_us,
+        };
 
         let record = Record {
             timestamp_us,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod message;
 mod pipeline;
 mod remote;
 mod runtime;
+mod timestamp;
 
 use crate::cfg::parse_config_file;
 use crate::input::InputBuilder;

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,6 +1,7 @@
 use crate::formats::json::extract_json_path;
 use serde::Deserialize;
 use serde_json::Value;
+use std::fmt;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -15,7 +16,7 @@ pub struct TimestampMapping {
     pub format: TimestampFormat,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TimestampFormat {
     UnixS,
@@ -26,6 +27,78 @@ pub enum TimestampFormat {
     Iso8601,
     RosStamp,
 }
+
+impl fmt::Display for TimestampFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            TimestampFormat::UnixS => "unix_s",
+            TimestampFormat::UnixMs => "unix_ms",
+            TimestampFormat::UnixUs => "unix_us",
+            TimestampFormat::UnixNs => "unix_ns",
+            TimestampFormat::Iso8601 => "iso8601",
+            TimestampFormat::RosStamp => "ros_stamp",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimeResolutionError {
+    pub source_kind: &'static str,
+    pub source_name: String,
+    pub reason: TimeResolutionErrorReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimeResolutionErrorReason {
+    ResolutionFailed,
+    ParsingFailed { format: TimestampFormat },
+}
+
+impl TimeResolutionError {
+    pub fn resolution_failed(source_kind: &'static str, source_name: &str) -> Self {
+        Self {
+            source_kind,
+            source_name: source_name.to_string(),
+            reason: TimeResolutionErrorReason::ResolutionFailed,
+        }
+    }
+
+    pub fn parsing_failed(
+        source_kind: &'static str,
+        source_name: &str,
+        format: &TimestampFormat,
+    ) -> Self {
+        Self {
+            source_kind,
+            source_name: source_name.to_string(),
+            reason: TimeResolutionErrorReason::ParsingFailed {
+                format: format.clone(),
+            },
+        }
+    }
+}
+
+impl fmt::Display for TimeResolutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.reason {
+            TimeResolutionErrorReason::ResolutionFailed => write!(
+                f,
+                "timestamp {} '{}' could not be resolved",
+                self.source_kind, self.source_name
+            ),
+            TimeResolutionErrorReason::ParsingFailed { format } => write!(
+                f,
+                "timestamp {} '{}' could not be parsed as {}",
+                self.source_kind, self.source_name, format
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TimeResolutionError {}
+
+pub type TimeResolutionResult = Result<u64, TimeResolutionError>;
 
 impl TimestampMapping {
     pub fn source_count(&self) -> usize {
@@ -39,12 +112,26 @@ impl TimestampMapping {
     }
 }
 
-pub fn resolve_from_json(decoded: &Value, field: &str, format: &TimestampFormat) -> Option<u64> {
-    extract_json_path(decoded, field).and_then(|value| parse_timestamp_us(value, format))
+pub fn resolve_from_json(
+    decoded: &Value,
+    field: &str,
+    format: &TimestampFormat,
+) -> TimeResolutionResult {
+    let Some(value) = extract_json_path(decoded, field) else {
+        return Err(TimeResolutionError::resolution_failed("field", field));
+    };
+
+    parse_timestamp_us(value, format)
+        .ok_or_else(|| TimeResolutionError::parsing_failed("field", field, format))
 }
 
-pub fn resolve_from_string(value: &str, format: &TimestampFormat) -> Option<u64> {
-    match format {
+pub fn resolve_from_string(
+    value: &str,
+    source_kind: &'static str,
+    source_name: &str,
+    format: &TimestampFormat,
+) -> TimeResolutionResult {
+    let timestamp_us = match format {
         TimestampFormat::UnixS => parse_decimal_to_us(value, 1_000_000.0),
         TimestampFormat::UnixMs => parse_decimal_to_us(value, 1_000.0),
         TimestampFormat::UnixUs => parse_decimal_to_us(value, 1.0),
@@ -53,7 +140,10 @@ pub fn resolve_from_string(value: &str, format: &TimestampFormat) -> Option<u64>
         TimestampFormat::RosStamp => serde_json::from_str::<Value>(value)
             .ok()
             .and_then(|value| parse_ros_stamp_us(&value)),
-    }
+    };
+
+    timestamp_us
+        .ok_or_else(|| TimeResolutionError::parsing_failed(source_kind, source_name, format))
 }
 
 pub fn parse_timestamp_us(value: &Value, format: &TimestampFormat) -> Option<u64> {
@@ -118,7 +208,10 @@ fn parse_unsigned_integer(value: &Value) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{TimestampFormat, parse_timestamp_us, resolve_from_json, resolve_from_string};
+    use super::{
+        TimeResolutionError, TimeResolutionErrorReason, TimestampFormat, parse_timestamp_us,
+        resolve_from_json, resolve_from_string,
+    };
     use rstest::rstest;
     use serde_json::json;
 
@@ -138,8 +231,13 @@ mod tests {
     #[test]
     fn parses_iso8601_strings() {
         assert_eq!(
-            resolve_from_string("1970-01-01T00:00:01.500Z", &TimestampFormat::Iso8601),
-            Some(1_500_000)
+            resolve_from_string(
+                "1970-01-01T00:00:01.500Z",
+                "property",
+                "event_time",
+                &TimestampFormat::Iso8601
+            ),
+            Ok(1_500_000)
         );
     }
 
@@ -159,7 +257,42 @@ mod tests {
 
         assert_eq!(
             resolve_from_json(&value, "meta.timestamp", &TimestampFormat::UnixMs),
-            Some(1_500_000)
+            Ok(1_500_000)
+        );
+    }
+
+    #[test]
+    fn reports_unresolved_json_field() {
+        let value = json!({ "meta": {} });
+
+        let err = resolve_from_json(&value, "meta.timestamp", &TimestampFormat::UnixMs)
+            .expect_err("missing field should fail");
+
+        assert_eq!(
+            err,
+            TimeResolutionError::resolution_failed("field", "meta.timestamp")
+        );
+    }
+
+    #[test]
+    fn reports_unparseable_string_source() {
+        let err = resolve_from_string(
+            "not-a-time",
+            "property",
+            "event_time",
+            &TimestampFormat::UnixMs,
+        )
+        .expect_err("invalid timestamp should fail");
+
+        assert_eq!(
+            err,
+            TimeResolutionError {
+                source_kind: "property",
+                source_name: "event_time".to_string(),
+                reason: TimeResolutionErrorReason::ParsingFailed {
+                    format: TimestampFormat::UnixMs,
+                },
+            }
         );
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,165 @@
+use crate::formats::json::extract_json_path;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimestampMapping {
+    #[serde(default)]
+    pub field: Option<String>,
+    #[serde(default)]
+    pub property: Option<String>,
+    #[serde(default)]
+    pub header: Option<String>,
+    #[serde(default)]
+    pub format: TimestampFormat,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TimestampFormat {
+    UnixS,
+    UnixMs,
+    #[default]
+    UnixUs,
+    UnixNs,
+    Iso8601,
+    RosStamp,
+}
+
+impl TimestampMapping {
+    pub fn source_count(&self) -> usize {
+        usize::from(self.field.is_some())
+            + usize::from(self.property.is_some())
+            + usize::from(self.header.is_some())
+    }
+
+    pub fn has_field(&self) -> bool {
+        self.field.is_some()
+    }
+}
+
+pub fn resolve_from_json(decoded: &Value, field: &str, format: &TimestampFormat) -> Option<u64> {
+    extract_json_path(decoded, field).and_then(|value| parse_timestamp_us(value, format))
+}
+
+pub fn resolve_from_string(value: &str, format: &TimestampFormat) -> Option<u64> {
+    match format {
+        TimestampFormat::UnixS => parse_decimal_to_us(value, 1_000_000.0),
+        TimestampFormat::UnixMs => parse_decimal_to_us(value, 1_000.0),
+        TimestampFormat::UnixUs => parse_decimal_to_us(value, 1.0),
+        TimestampFormat::UnixNs => parse_decimal_to_us(value, 0.001),
+        TimestampFormat::Iso8601 => parse_iso8601_us(value),
+        TimestampFormat::RosStamp => serde_json::from_str::<Value>(value)
+            .ok()
+            .and_then(|value| parse_ros_stamp_us(&value)),
+    }
+}
+
+pub fn parse_timestamp_us(value: &Value, format: &TimestampFormat) -> Option<u64> {
+    match format {
+        TimestampFormat::UnixS => parse_value_decimal_to_us(value, 1_000_000.0),
+        TimestampFormat::UnixMs => parse_value_decimal_to_us(value, 1_000.0),
+        TimestampFormat::UnixUs => parse_value_decimal_to_us(value, 1.0),
+        TimestampFormat::UnixNs => parse_value_decimal_to_us(value, 0.001),
+        TimestampFormat::Iso8601 => value.as_str().and_then(parse_iso8601_us),
+        TimestampFormat::RosStamp => parse_ros_stamp_us(value),
+    }
+}
+
+fn parse_value_decimal_to_us(value: &Value, multiplier: f64) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_f64().and_then(|v| decimal_to_us(v, multiplier)),
+        Value::String(value) => parse_decimal_to_us(value, multiplier),
+        _ => None,
+    }
+}
+
+fn parse_decimal_to_us(value: &str, multiplier: f64) -> Option<u64> {
+    value
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .and_then(|value| decimal_to_us(value, multiplier))
+}
+
+fn decimal_to_us(value: f64, multiplier: f64) -> Option<u64> {
+    let micros = value * multiplier;
+    if !micros.is_finite() || micros < 0.0 || micros > u64::MAX as f64 {
+        return None;
+    }
+    Some(micros as u64)
+}
+
+fn parse_iso8601_us(value: &str) -> Option<u64> {
+    let micros = chrono::DateTime::parse_from_rfc3339(value)
+        .ok()?
+        .timestamp_micros();
+    u64::try_from(micros).ok()
+}
+
+fn parse_ros_stamp_us(value: &Value) -> Option<u64> {
+    let sec = parse_unsigned_integer(value.get("sec")?)?;
+    let nanos = value
+        .get("nanosec")
+        .or_else(|| value.get("nsec"))
+        .and_then(parse_unsigned_integer)?;
+
+    sec.checked_mul(1_000_000)?.checked_add(nanos / 1_000)
+}
+
+fn parse_unsigned_integer(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_u64(),
+        Value::String(value) => value.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TimestampFormat, parse_timestamp_us, resolve_from_json, resolve_from_string};
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    #[case(TimestampFormat::UnixS, json!(1.5), 1_500_000)]
+    #[case(TimestampFormat::UnixMs, json!(1500), 1_500_000)]
+    #[case(TimestampFormat::UnixUs, json!(1_500_000), 1_500_000)]
+    #[case(TimestampFormat::UnixNs, json!(1_500_000_000), 1_500_000)]
+    fn parses_unix_formats(
+        #[case] format: TimestampFormat,
+        #[case] value: serde_json::Value,
+        #[case] expected: u64,
+    ) {
+        assert_eq!(parse_timestamp_us(&value, &format), Some(expected));
+    }
+
+    #[test]
+    fn parses_iso8601_strings() {
+        assert_eq!(
+            resolve_from_string("1970-01-01T00:00:01.500Z", &TimestampFormat::Iso8601),
+            Some(1_500_000)
+        );
+    }
+
+    #[test]
+    fn parses_ros_stamp_objects() {
+        let value = json!({ "sec": 42, "nanosec": 123_456_789u64 });
+
+        assert_eq!(
+            parse_timestamp_us(&value, &TimestampFormat::RosStamp),
+            Some(42_123_456)
+        );
+    }
+
+    #[test]
+    fn resolves_timestamp_from_json_field_path() {
+        let value = json!({ "meta": { "timestamp": "1500" } });
+
+        assert_eq!(
+            resolve_from_json(&value, "meta.timestamp", &TimestampFormat::UnixMs),
+            Some(1_500_000)
+        );
+    }
+}


### PR DESCRIPTION
Closes #38

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added a shared timestamp mapping module that resolves configured source timestamps into ReductStore record timestamps.
- Added HTTP timestamp mapping from JSON response fields or response headers.
- Added MQTT timestamp mapping from JSON/protobuf payload fields or MQTT v5 user properties.
- Added ROS1 timestamp mapping from decoded message fields such as `header.stamp`.
- Documented timestamp mapping examples and performance notes for HTTP, MQTT, and ROS1 inputs.

### Related issues

#38

### Does this PR introduce a breaking change?

No.

### Other information:

Tested with:

- `cargo test`
- `cargo test --features http,mqtt,ros1`