### PR TITLE
Store ROS schema under  attachment key

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -43,7 +43,7 @@ runs:
           source "${{ inputs.ros-setup-script }}"
           set -u
         fi
-        cargo test ${{ inputs.cargo-args }} ci_reductstore_roundtrip_data_and_attachment -- --nocapture
+        cargo test ${{ inputs.cargo-args }} ci_reductstore -- --nocapture
 
     - name: Run code coverage
       shell: bash

--- a/.github/actions/ros1-input-smoke/action.yml
+++ b/.github/actions/ros1-input-smoke/action.yml
@@ -74,8 +74,8 @@ runs:
 
         echo "=== [ros1-it] Verifying ROS attachment payload ==="
         attach_head="$(curl -sfI "${REDUCT_URL}/api/v1/b/${BUCKET}/camera-raw/\$meta")"
-        if ! echo "$attach_head" | grep -Fq 'x-reduct-label-key: $ros'; then
-          echo "Attachment key \$ros is missing in attachment headers:"
+        if ! echo "$attach_head" | grep -Fq 'x-reduct-label-key: $schema'; then
+          echo "Attachment key \$schema is missing in attachment headers:"
           echo "$attach_head"
           exit 1
         fi

--- a/.github/actions/ros2-input-smoke/action.yml
+++ b/.github/actions/ros2-input-smoke/action.yml
@@ -129,8 +129,8 @@ runs:
 
         echo "=== [ros2-it] Verifying ROS attachment payload ==="
         attach_head="$(curl -sfI "${REDUCT_URL}/api/v1/b/${BUCKET}/chatter/\$meta")"
-        if ! echo "$attach_head" | grep -Fq 'x-reduct-label-key: $ros'; then
-          echo "Attachment key \$ros is missing in attachment headers:"
+        if ! echo "$attach_head" | grep -Fq 'x-reduct-label-key: $schema'; then
+          echo "Attachment key \$schema is missing in attachment headers:"
           echo "$attach_head"
           exit 1
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- ROS1/ROS2 schema metadata is now stored under the `$schema` attachment key by default, falling back to the legacy `$ros` key for entries that already carry one.
+
 ## 0.3.1 - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ROS1/ROS2 schema metadata is now stored under the `$schema` attachment key by default, falling back to the legacy `$ros` key for entries that already carry one.
+- ROS1/ROS2 schema metadata is now stored under the `$schema` attachment key by default, falling back to the legacy `$ros` key for entries that already carry one, [PR-51](https://github.com/reductstore/reduct-bridge/pull/51).
 
 ## 0.3.1 - 2026-06-04
 

--- a/src/formats/protobuf.rs
+++ b/src/formats/protobuf.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use super::{AttachmentContext, DecodeFormat, FormatAttachment, FormatHandler};
 use crate::formats::json::{extract_json_path, value_to_label};
+use crate::message::SCHEMA_ATTACHMENT_KEY;
 
 pub(crate) struct ProtobufHandler {
     schemas: HashMap<String, SchemaArtifact>,
@@ -90,7 +91,7 @@ impl FormatHandler for ProtobufHandler {
             )
         })?;
         Ok(FormatAttachment {
-            key: "$schema".to_string(),
+            key: SCHEMA_ATTACHMENT_KEY.to_string(),
             payload: serde_json::json!({
                 "encoding": "protobuf",
                 "topic": context.publish_topic,
@@ -343,7 +344,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(attachment.key, "$schema");
+        assert_eq!(attachment.key, SCHEMA_ATTACHMENT_KEY);
         assert_eq!(attachment.payload["encoding"], "protobuf");
         assert_eq!(attachment.payload["topic"], "factory/line-1/telemetry");
         assert_eq!(

--- a/src/input/ros1/topic_runtime.rs
+++ b/src/input/ros1/topic_runtime.rs
@@ -1,6 +1,6 @@
 use super::instance::PublisherDecoder;
 use super::{Ros1Instance, Ros1TopicConfig};
-use crate::message::{Attachment, Message, Record};
+use crate::message::{Attachment, Message, Record, SCHEMA_ATTACHMENT_KEY};
 use crate::timestamp::TimeResolutionError;
 use log::warn;
 use rosrust::{DynamicMsg, RawMessage};
@@ -124,7 +124,7 @@ impl TopicRuntime {
         });
         let attachment = Attachment {
             entry_name: self.entry_name.clone(),
-            key: "$ros".to_string(),
+            key: SCHEMA_ATTACHMENT_KEY.to_string(),
             payload: attachment_payload,
         };
         if let Err(err) = self
@@ -241,8 +241,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case("std_msgs/String", "string data", "$ros")]
-    #[case("", "", "$ros")]
+    #[case("std_msgs/String", "string data", "$schema")]
+    #[case("", "", "$schema")]
     fn handle_connect_emits_attachment(
         static_topic_cfg: Ros1TopicConfig,
         #[case] schema_name: &str,

--- a/src/input/ros1/topic_runtime.rs
+++ b/src/input/ros1/topic_runtime.rs
@@ -241,8 +241,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case("std_msgs/String", "string data", "$schema")]
-    #[case("", "", "$schema")]
+    #[case("std_msgs/String", "string data", SCHEMA_ATTACHMENT_KEY)]
+    #[case("", "", SCHEMA_ATTACHMENT_KEY)]
     fn handle_connect_emits_attachment(
         static_topic_cfg: Ros1TopicConfig,
         #[case] schema_name: &str,

--- a/src/input/ros1/topic_runtime.rs
+++ b/src/input/ros1/topic_runtime.rs
@@ -177,7 +177,7 @@ fn current_timestamp_us() -> u64 {
 mod tests {
     use super::TopicRuntime;
     use crate::input::ros1::{Ros1LabelRule, Ros1TopicConfig};
-    use crate::message::Message;
+    use crate::message::{Message, SCHEMA_ATTACHMENT_KEY};
     use rosrust::RawMessage;
     use rstest::{fixture, rstest};
     use std::collections::HashMap;

--- a/src/input/ros2/README.md
+++ b/src/input/ros2/README.md
@@ -89,7 +89,7 @@ reduct-bridge /etc/reduct-bridge/reduct-bridge.toml
 ```
 
 - Raw record content is stored as serialized CDR with content type `application/cdr`.
-- Message schema metadata is stored automatically in the `$ros` attachment.
+- Message schema metadata is stored automatically for ROS topics.
 - Dynamic field labels are decoded with `ros2_message` using the resolved `.msg` schema text.
 - When `timestamp = { field = "...", format = "..." }` is configured, the bridge decodes the ROS2 message payload even if you do not configure dynamic label rules.
 

--- a/src/input/ros2/topic_runtime.rs
+++ b/src/input/ros2/topic_runtime.rs
@@ -1,6 +1,6 @@
 use super::{Ros2Instance, Ros2LabelRule};
 use crate::formats::ros2::Ros2DynamicParser;
-use crate::message::{Attachment, Message, Record};
+use crate::message::{Attachment, Message, Record, SCHEMA_ATTACHMENT_KEY};
 use crate::timestamp::{TimeResolutionError, TimestampMapping};
 use bytes::Bytes;
 use log::warn;
@@ -39,7 +39,7 @@ impl Ros2TopicRuntime {
     pub(super) fn emit_attachment(&self, schema_name: &str, schema: &str) {
         let attachment = Attachment {
             entry_name: self.entry_name.clone(),
-            key: "$ros".to_string(),
+            key: SCHEMA_ATTACHMENT_KEY.to_string(),
             payload: serde_json::json!({
                 "encoding": "cdr",
                 "topic": self.topic_name,
@@ -182,7 +182,7 @@ mod tests {
         match rx.blocking_recv().expect("attachment should be sent") {
             Message::Attachment(attachment) => {
                 assert_eq!(attachment.entry_name, "entry_a");
-                assert_eq!(attachment.key, "$ros");
+                assert_eq!(attachment.key, "$schema");
                 assert_eq!(attachment.payload["topic"], "/topic/a");
                 assert_eq!(attachment.payload["schema_name"], "std_msgs/msg/String");
                 assert_eq!(attachment.payload["schema"], "string data");

--- a/src/input/ros2/topic_runtime.rs
+++ b/src/input/ros2/topic_runtime.rs
@@ -182,7 +182,7 @@ mod tests {
         match rx.blocking_recv().expect("attachment should be sent") {
             Message::Attachment(attachment) => {
                 assert_eq!(attachment.entry_name, "entry_a");
-                assert_eq!(attachment.key, "$schema");
+                assert_eq!(attachment.key, SCHEMA_ATTACHMENT_KEY);
                 assert_eq!(attachment.payload["topic"], "/topic/a");
                 assert_eq!(attachment.payload["schema_name"], "std_msgs/msg/String");
                 assert_eq!(attachment.payload["schema"], "string data");

--- a/src/input/ros2/topic_runtime.rs
+++ b/src/input/ros2/topic_runtime.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::Ros2TopicRuntime;
     use crate::formats::ros2::Ros2DynamicParser;
     use crate::input::ros2::Ros2LabelRule;
-    use crate::message::Message;
+    use crate::message::{Message, SCHEMA_ATTACHMENT_KEY};
     use crate::timestamp::{TimestampFormat, TimestampMapping};
     use rstest::{fixture, rstest};
     use std::collections::HashMap;

--- a/src/message.rs
+++ b/src/message.rs
@@ -25,6 +25,11 @@ pub struct Record {
     pub labels: HashMap<String, String>,
 }
 
+pub const SCHEMA_ATTACHMENT_KEY: &str = "$schema";
+
+#[cfg(any(feature = "ros1", feature = "ros2"))]
+pub const LEGACY_ROS_ATTACHMENT_KEY: &str = "$ros";
+
 #[derive(Debug, Clone)]
 #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
 pub struct Attachment {

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
 use crate::message::Attachment;
+#[cfg(any(feature = "ros1", feature = "ros2"))]
+use crate::message::{LEGACY_ROS_ATTACHMENT_KEY, SCHEMA_ATTACHMENT_KEY};
 use crate::message::{Message, Record};
 use crate::remote::RemoteInstanceLauncher;
 use crate::runtime::ComponentRuntime;
@@ -196,6 +198,25 @@ impl ReductInstance {
         }
     }
 
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    async fn resolve_attachment_key(
+        cfg: &RemoteConfig,
+        bucket: &Bucket,
+        mut attachment: Attachment,
+    ) -> Attachment {
+        if attachment.key == SCHEMA_ATTACHMENT_KEY {
+            if let Some(entry) = Self::normalize_entry_path(&cfg.prefix, &attachment.entry_name) {
+                if matches!(
+                    bucket.read_attachments(&entry).await,
+                    Ok(existing) if existing.contains_key(LEGACY_ROS_ATTACHMENT_KEY)
+                ) {
+                    attachment.key = LEGACY_ROS_ATTACHMENT_KEY.to_string();
+                }
+            }
+        }
+        attachment
+    }
+
     #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     async fn write_attachment(cfg: &RemoteConfig, bucket: &Bucket, attachment: &Attachment) {
         let Some(entry) = Self::normalize_entry_path(&cfg.prefix, &attachment.entry_name) else {
@@ -337,6 +358,8 @@ impl RemoteInstanceLauncher for ReductInstance {
                             }
                             #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
                             Some(Message::Attachment(attachment)) => {
+                                #[cfg(any(feature = "ros1", feature = "ros2"))]
+                                let attachment = Self::resolve_attachment_key(&cfg, &bucket, attachment).await;
                                 Self::write_attachment(&cfg, &bucket, &attachment).await;
                                 Self::update_attachment_cache(&cfg, &mut attachment_cache, &attachment);
                             }
@@ -701,7 +724,7 @@ mod ci_tests {
     fn ros_attachment_message() -> Message {
         Message::Attachment(Attachment {
             entry_name: "entry".to_string(),
-            key: "$ros".to_string(),
+            key: "$schema".to_string(),
             payload: json!({
                 "encoding": "ros1",
                 "schema": "float64 x",
@@ -847,10 +870,51 @@ mod ci_tests {
             .read_attachments("it/entry")
             .await
             .expect("read attachments");
-        let payload = attachments.get("$ros").expect("$ros attachment");
+        let payload = attachments.get("$schema").expect("$schema attachment");
         assert_eq!(payload["encoding"], "ros1");
         assert_eq!(payload["topic"], "/sensor/pos");
         assert_eq!(payload["schema_name"], "geometry_msgs/Point");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
+    async fn ci_reductstore_keeps_legacy_ros_attachment_key(ros_attachment_message: Message) {
+        let suffix = unique_suffix();
+        let bucket_name = format!("it-{suffix}");
+        let url = reductstore_url();
+        let client = reductstore_client().await;
+
+        let bucket = client
+            .create_bucket(&bucket_name)
+            .exist_ok(true)
+            .send()
+            .await
+            .expect("create bucket");
+
+        bucket
+            .write_attachments(
+                "it/entry",
+                HashMap::from([("$ros".to_string(), json!({"encoding": "ros1"}))]),
+            )
+            .await
+            .expect("seed legacy attachment");
+
+        let remote = ReductInstance::new(remote_config(url, bucket_name.clone(), None, 300_000));
+        write_data_and_stop(remote, ros_attachment_message).await;
+
+        let attachments = bucket
+            .read_attachments("it/entry")
+            .await
+            .expect("read attachments");
+        let payload = attachments
+            .get("$ros")
+            .expect("legacy $ros attachment should be updated in place");
+        assert_eq!(payload["topic"], "/sensor/pos");
+        assert!(
+            !attachments.contains_key("$schema"),
+            "should not write a $schema attachment when a legacy $ros key exists"
+        );
     }
 
     #[rstest]
@@ -882,7 +946,7 @@ mod ci_tests {
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         for _ in 0..10 {
             match bucket.read_attachments("it/entry").await {
-                Ok(attachments) if attachments.contains_key("$ros") => break,
+                Ok(attachments) if attachments.contains_key("$schema") => break,
                 Ok(_) => {}
                 Err(err) if err.status() == ErrorCode::NotFound => {}
                 Err(err) => panic!("read attachments: {err:?}"),
@@ -894,7 +958,7 @@ mod ci_tests {
         for _ in 0..10 {
             match bucket.remove_attachments("it/entry", None).await {
                 Ok(()) => match bucket.read_attachments("it/entry").await {
-                    Ok(attachments) if !attachments.contains_key("$ros") => {
+                    Ok(attachments) if !attachments.contains_key("$schema") => {
                         removed = true;
                         break;
                     }
@@ -916,13 +980,13 @@ mod ci_tests {
 
         assert!(
             removed,
-            "expected $ros attachment to be removed before resend"
+            "expected $schema attachment to be removed before resend"
         );
 
         let mut restored = false;
         for _ in 0..30 {
             match bucket.read_attachments("it/entry").await {
-                Ok(attachments) if attachments.contains_key("$ros") => {
+                Ok(attachments) if attachments.contains_key("$schema") => {
                     restored = true;
                     break;
                 }
@@ -936,7 +1000,7 @@ mod ci_tests {
         runtime.tx.send(Message::Stop).await.expect("send stop");
         runtime.task.await.expect("join remote");
 
-        assert!(restored, "expected $ros attachment to be resent");
+        assert!(restored, "expected $schema attachment to be resent");
     }
 
     #[rstest]
@@ -968,7 +1032,7 @@ mod ci_tests {
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         for _ in 0..10 {
             match bucket.read_attachments("it/entry").await {
-                Ok(attachments) if attachments.contains_key("$ros") => break,
+                Ok(attachments) if attachments.contains_key("$schema") => break,
                 Ok(_) => {}
                 Err(err) if err.status() == ErrorCode::NotFound => {}
                 Err(err) => panic!("read attachments: {err:?}"),
@@ -987,7 +1051,7 @@ mod ci_tests {
         runtime.task.await.expect("join remote");
 
         match bucket.read_attachments("it/entry").await {
-            Ok(attachments) => assert!(!attachments.contains_key("$ros")),
+            Ok(attachments) => assert!(!attachments.contains_key("$schema")),
             Err(err) if err.status() == ErrorCode::NotFound => {}
             Err(err) => panic!("read attachments: {err:?}"),
         }

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -878,7 +878,7 @@ mod ci_tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
     async fn ci_reductstore_keeps_legacy_ros_attachment_key(ros_attachment_message: Message) {
         let suffix = unique_suffix();
         let bucket_name = format!("it-{suffix}");

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -621,6 +621,8 @@ mod unit_tests {
 #[cfg(all(test, feature = "ci"))]
 mod ci_tests {
     use super::{CreateBucketConfig, ReductInstance, RemoteConfig, SCHEMA_ATTACHMENT_KEY};
+    #[cfg(any(feature = "ros1", feature = "ros2"))]
+    use super::LEGACY_ROS_ATTACHMENT_KEY;
     #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     use crate::message::Attachment;
     use crate::message::{Message, Record};

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -620,9 +620,9 @@ mod unit_tests {
 
 #[cfg(all(test, feature = "ci"))]
 mod ci_tests {
-    use super::{CreateBucketConfig, ReductInstance, RemoteConfig, SCHEMA_ATTACHMENT_KEY};
     #[cfg(any(feature = "ros1", feature = "ros2"))]
     use super::LEGACY_ROS_ATTACHMENT_KEY;
+    use super::{CreateBucketConfig, ReductInstance, RemoteConfig, SCHEMA_ATTACHMENT_KEY};
     #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     use crate::message::Attachment;
     use crate::message::{Message, Record};

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -620,7 +620,7 @@ mod unit_tests {
 
 #[cfg(all(test, feature = "ci"))]
 mod ci_tests {
-    use super::{CreateBucketConfig, ReductInstance, RemoteConfig};
+    use super::{CreateBucketConfig, ReductInstance, RemoteConfig, SCHEMA_ATTACHMENT_KEY};
     #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
     use crate::message::Attachment;
     use crate::message::{Message, Record};

--- a/src/remote/reduct/mod.rs
+++ b/src/remote/reduct/mod.rs
@@ -14,7 +14,9 @@
 #[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
 use crate::message::Attachment;
 #[cfg(any(feature = "ros1", feature = "ros2"))]
-use crate::message::{LEGACY_ROS_ATTACHMENT_KEY, SCHEMA_ATTACHMENT_KEY};
+use crate::message::LEGACY_ROS_ATTACHMENT_KEY;
+#[cfg(any(feature = "ros1", feature = "ros2", feature = "mqtt"))]
+use crate::message::SCHEMA_ATTACHMENT_KEY;
 use crate::message::{Message, Record};
 use crate::remote::RemoteInstanceLauncher;
 use crate::runtime::ComponentRuntime;
@@ -724,7 +726,7 @@ mod ci_tests {
     fn ros_attachment_message() -> Message {
         Message::Attachment(Attachment {
             entry_name: "entry".to_string(),
-            key: "$schema".to_string(),
+            key: SCHEMA_ATTACHMENT_KEY.to_string(),
             payload: json!({
                 "encoding": "ros1",
                 "schema": "float64 x",
@@ -870,7 +872,9 @@ mod ci_tests {
             .read_attachments("it/entry")
             .await
             .expect("read attachments");
-        let payload = attachments.get("$schema").expect("$schema attachment");
+        let payload = attachments
+            .get(SCHEMA_ATTACHMENT_KEY)
+            .expect("$schema attachment");
         assert_eq!(payload["encoding"], "ros1");
         assert_eq!(payload["topic"], "/sensor/pos");
         assert_eq!(payload["schema_name"], "geometry_msgs/Point");
@@ -895,7 +899,10 @@ mod ci_tests {
         bucket
             .write_attachments(
                 "it/entry",
-                HashMap::from([("$ros".to_string(), json!({"encoding": "ros1"}))]),
+                HashMap::from([(
+                    LEGACY_ROS_ATTACHMENT_KEY.to_string(),
+                    json!({"encoding": "ros1"}),
+                )]),
             )
             .await
             .expect("seed legacy attachment");
@@ -908,11 +915,11 @@ mod ci_tests {
             .await
             .expect("read attachments");
         let payload = attachments
-            .get("$ros")
+            .get(LEGACY_ROS_ATTACHMENT_KEY)
             .expect("legacy $ros attachment should be updated in place");
         assert_eq!(payload["topic"], "/sensor/pos");
         assert!(
-            !attachments.contains_key("$schema"),
+            !attachments.contains_key(SCHEMA_ATTACHMENT_KEY),
             "should not write a $schema attachment when a legacy $ros key exists"
         );
     }
@@ -946,7 +953,7 @@ mod ci_tests {
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         for _ in 0..10 {
             match bucket.read_attachments("it/entry").await {
-                Ok(attachments) if attachments.contains_key("$schema") => break,
+                Ok(attachments) if attachments.contains_key(SCHEMA_ATTACHMENT_KEY) => break,
                 Ok(_) => {}
                 Err(err) if err.status() == ErrorCode::NotFound => {}
                 Err(err) => panic!("read attachments: {err:?}"),
@@ -958,7 +965,7 @@ mod ci_tests {
         for _ in 0..10 {
             match bucket.remove_attachments("it/entry", None).await {
                 Ok(()) => match bucket.read_attachments("it/entry").await {
-                    Ok(attachments) if !attachments.contains_key("$schema") => {
+                    Ok(attachments) if !attachments.contains_key(SCHEMA_ATTACHMENT_KEY) => {
                         removed = true;
                         break;
                     }
@@ -986,7 +993,7 @@ mod ci_tests {
         let mut restored = false;
         for _ in 0..30 {
             match bucket.read_attachments("it/entry").await {
-                Ok(attachments) if attachments.contains_key("$schema") => {
+                Ok(attachments) if attachments.contains_key(SCHEMA_ATTACHMENT_KEY) => {
                     restored = true;
                     break;
                 }
@@ -1032,7 +1039,7 @@ mod ci_tests {
         let bucket = client.get_bucket(&bucket_name).await.expect("get bucket");
         for _ in 0..10 {
             match bucket.read_attachments("it/entry").await {
-                Ok(attachments) if attachments.contains_key("$schema") => break,
+                Ok(attachments) if attachments.contains_key(SCHEMA_ATTACHMENT_KEY) => break,
                 Ok(_) => {}
                 Err(err) if err.status() == ErrorCode::NotFound => {}
                 Err(err) => panic!("read attachments: {err:?}"),
@@ -1051,7 +1058,7 @@ mod ci_tests {
         runtime.task.await.expect("join remote");
 
         match bucket.read_attachments("it/entry").await {
-            Ok(attachments) => assert!(!attachments.contains_key("$schema")),
+            Ok(attachments) => assert!(!attachments.contains_key(SCHEMA_ATTACHMENT_KEY)),
             Err(err) if err.status() == ErrorCode::NotFound => {}
             Err(err) => panic!("read attachments: {err:?}"),
         }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Update

### What was changed?

ROS1/ROS2 schema metadata is now stored under the `$schema` attachment key by default, falling back to the legacy `$ros` key for entries that already carry one.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
