### PR TITLE
Relax nounset while sourcing ROS setup in the entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Relax nounset while sourcing ROS setup in the entrypoint, [PR-54](https://github.com/reductstore/reduct-bridge/pull/54).
+
 ## 0.4.0 - 2026-06-25
 
 ### Changed

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 if [ -n "${ROS_DISTRO:-}" ] && [ -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]; then
+    # ROS setup scripts reference variables that may be unset (e.g.
+    # AMENT_TRACE_SETUP_FILES, AMENT_PYTHON_EXECUTABLE), which aborts under
+    # `set -u`. Relax nounset only while sourcing, then restore it.
+    set +u
     source "/opt/ros/${ROS_DISTRO}/setup.bash"
+    set -u
 fi
 
 data_path="${RS_DATA_PATH:-/data}"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The Docker entrypoint runs with errexit, nounset, and pipefail, then sources /opt/ros/$ROS_DISTRO/setup.bash. The ROS setup scripts reference variables that can be unset (for example AMENT_TRACE_SETUP_FILES and AMENT_PYTHON_EXECUTABLE), so nounset aborts the container before the bridge process starts. Every published ros2 image hits this on a plain run with no config.

This change disables nounset only around the ROS source and restores it immediately after, keeping errexit and pipefail active for the rest of the script.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
