### PR TITLE
ci: use incremental cargo cache

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -1,5 +1,5 @@
 name: 'AWS Credentials and Cargo Cache'
-description: 'Configures AWS credentials via OIDC and sets up Cargo cache.'
+description: 'Configures Cargo target caching, S3-backed sccache, and a small Cargo download cache.'
 inputs:
   target:
     description: 'Target triple.'
@@ -42,16 +42,65 @@ runs:
     #        aws-secret-access-key: ${{ inputs.secret-access-key }}
     #        aws-region: eu-central
 
-    - name: Use cache for Cargo
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Configure sccache
+      shell: bash
+      run: |
+        export RUSTC_WRAPPER=sccache
+        export SCCACHE_BUCKET=reduct-cache
+        export SCCACHE_ENDPOINT=https://fsn1.your-objectstorage.com
+        export SCCACHE_REGION=fsn1
+        export SCCACHE_S3_KEY_PREFIX="sccache/${{ github.repository }}/${{ inputs.os }}/${{ inputs.target }}/${{ inputs.profile }}/${{ inputs.variant }}/rust${RUST_MINOR}"
+        export SCCACHE_IDLE_TIMEOUT=0
+        export AWS_ACCESS_KEY_ID="${{ inputs.access-key-id }}"
+        export AWS_SECRET_ACCESS_KEY="${{ inputs.secret-access-key }}"
+        export AWS_REGION=fsn1
+        export AWS_DEFAULT_REGION=fsn1
+
+        {
+          echo "RUSTC_WRAPPER=${RUSTC_WRAPPER}"
+          echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
+          echo "SCCACHE_ENDPOINT=${SCCACHE_ENDPOINT}"
+          echo "SCCACHE_REGION=${SCCACHE_REGION}"
+          echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
+          echo "SCCACHE_IDLE_TIMEOUT=${SCCACHE_IDLE_TIMEOUT}"
+          echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+          echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+          echo "AWS_REGION=${AWS_REGION}"
+          echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}"
+        } >> "$GITHUB_ENV"
+
+        sccache --start-server
+
+    - name: Use cache for Cargo downloads
       uses: runs-on/cache@v4
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-${{ inputs.os }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.variant }}-cargo-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          ~/.cargo/bin/cargo-export
+        key: ${{ runner.os }}-${{ inputs.os }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.variant }}-cargo-downloads-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.os }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.variant }}-cargo-downloads-rust${{ env.RUST_MINOR }}-
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: reduct-cache
+        RUNS_ON_S3_BUCKET_ENDPOINT: https://fsn1.your-objectstorage.com
+        AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-access-key }}
+        AWS_REGION: fsn1
+        AWS_DEFAULT_REGION: fsn1
+
+    - name: Use cache for Cargo target
+      uses: runs-on/cache@v4
+      with:
+        path: target/
+        key: ${{ runner.os }}-${{ inputs.os }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.variant }}-cargo-target-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.os }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.variant }}-cargo-target-rust${{ env.RUST_MINOR }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-
+          ${{ runner.os }}-${{ inputs.os }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.variant }}-cargo-target-rust${{ env.RUST_MINOR }}-
       env:
         RUNS_ON_S3_BUCKET_CACHE: reduct-cache
         RUNS_ON_S3_BUCKET_ENDPOINT: https://fsn1.your-objectstorage.com

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -81,7 +81,10 @@ runs:
 
     - name: Install cargo-export
       shell: bash
-      run: cargo install cargo-export --version 0.3.0 --locked --force
+      run: |
+        if ! command -v cargo-export >/dev/null 2>&1; then
+          cargo install cargo-export --version 0.3.0 --locked
+        fi
 
     - name: Build binary (PR)
       if: github.event_name == 'pull_request'
@@ -94,6 +97,11 @@ runs:
           set -u
         fi
         cargo build --locked --profile ci -p reduct-bridge --target ${{ inputs.target }} ${{ inputs.cargo-args }}
+
+    - name: Show sccache stats (PR)
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: sccache --show-stats
 
     - name: Upload binary (PR)
       uses: actions/upload-artifact@v4
@@ -114,6 +122,11 @@ runs:
           set -u
         fi
         cargo build --locked --profile release -p reduct-bridge --target ${{ inputs.target }} ${{ inputs.cargo-args }}
+
+    - name: Show sccache stats (Release)
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: sccache --show-stats
 
 
     - name: Upload binary (Release)
@@ -137,6 +150,11 @@ runs:
         fi
         cargo export target/${{ inputs.target }}/tests -- test --locked --profile ci --target ${{ inputs.target }} --bins ${{ inputs.cargo-args }} --features ci
 
+    - name: Show sccache stats after test export (PR)
+      if: github.event_name == 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
+      shell: bash
+      run: sccache --show-stats
+
     - name: Build and export tests (Release)
       if: github.event_name != 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
       shell: bash
@@ -148,6 +166,11 @@ runs:
           set -u
         fi
         cargo export target/${{ inputs.target }}/tests -- test --locked --profile release --target ${{ inputs.target }} --bins ${{ inputs.cargo-args }}
+
+    - name: Show sccache stats after test export (Release)
+      if: github.event_name != 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
+      shell: bash
+      run: sccache --show-stats
 
     - name: Upload tests
       uses: actions/upload-artifact@v4

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -18,6 +18,12 @@ inputs:
     description: 'Optional ROS setup script to source before cargo commands.'
     required: false
     default: ''
+  access-key-id:
+    description: 'AWS Access Key ID'
+    required: true
+  secret-access-key:
+    description: 'AWS Secret Access Key'
+    required: true
 runs:
   using: 'composite'
   steps:
@@ -45,6 +51,16 @@ runs:
       shell: bash
       run: cargo install cargo-llvm-cov --version 0.8.7 --locked --force
 
+    - name: AWS Credentials and Cargo Cache
+      uses: ./.github/actions/aws-cargo-cache
+      with:
+        os: ${{ inputs.os }}
+        target: ${{ inputs.target }}
+        profile: coverage
+        variant: coverage
+        access-key-id: ${{ inputs.access-key-id }}
+        secret-access-key: ${{ inputs.secret-access-key }}
+
     - name: Run ReductStore integration test (CI feature)
       shell: bash
       env:
@@ -60,6 +76,10 @@ runs:
         fi
         cargo test --locked ${{ inputs.cargo-args }} ci_reductstore_roundtrip_data_and_attachment -- --nocapture
 
+    - name: Show sccache stats after integration test
+      shell: bash
+      run: sccache --show-stats
+
     - name: Run code coverage
       shell: bash
       env:
@@ -74,6 +94,10 @@ runs:
           set -u
         fi
         cargo llvm-cov --locked --workspace ${{ inputs.cargo-args }} --lcov --output-path lcov.info
+
+    - name: Show sccache stats after coverage
+      shell: bash
+      run: sccache --show-stats
 
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,8 @@ jobs:
           action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
           cargo-args: --no-default-features --features ci,all-inputs
           ros-setup-script: /opt/ros/jazzy/setup.bash
+          access-key-id: ${{ secrets.S3_CACHE_ACCESS_KEY }}
+          secret-access-key: ${{ secrets.S3_CACHE_SECRET_KEY }}
 
       - name: Upload coverage to Codecov
         continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2022,7 +2022,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2467,7 +2467,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2535,7 +2535,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3419,7 +3419,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3513,16 +3513,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3540,31 +3531,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3574,22 +3548,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3598,22 +3560,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3622,22 +3572,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3646,22 +3584,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = "0.1.89"
 toml = "1.0.3"
 serde = { version = "1.0.228", features = ["derive"] }
 bytes = "1.11.1"
-reduct-rs = { version = "1.19.1" }
+reduct-rs = { version = "1.20.0" }
 anyhow = "1.0.102"
 log = "0.4.28"
 env_logger = "0.11.8"


### PR DESCRIPTION
## Summary
- switch the shared Cargo cache action to S3-backed `sccache`
- split Cargo downloads from `target/`, with commit-keyed target cache restore prefixes
- add cache/stats coverage to the coverage action
- avoid reinstalling `cargo-export` when restored from cache and print `sccache --show-stats`
- update `reduct-rs` to 1.20.0

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`
- YAML parse for workflow/action files
- `cargo test --locked --no-run`
