### PR TITLE
ci: skip S3 cargo cache without credentials

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -34,6 +34,22 @@ runs:
         else
           echo "Using preset RUST_MINOR=${RUST_MINOR}"
         fi
+
+    - name: Detect S3 cache credentials
+      id: s3_cache
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-access-key }}
+      run: |
+        if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "S3_CARGO_CACHE_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "S3_CARGO_CACHE_ENABLED=false" >> "$GITHUB_ENV"
+          echo "S3 Cargo cache is disabled because credentials are unavailable."
+        fi
     #
     #    - name: Configure AWS credentials via OIDC (org-wide role)
     #      uses: aws-actions/configure-aws-credentials@v4
@@ -43,9 +59,11 @@ runs:
     #        aws-region: eu-central
 
     - name: Install sccache
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure sccache
+      if: steps.s3_cache.outputs.enabled == 'true'
       shell: bash
       run: |
         export RUSTC_WRAPPER=sccache
@@ -75,6 +93,7 @@ runs:
         sccache --start-server
 
     - name: Use cache for Cargo downloads
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: runs-on/cache@v4
       with:
         path: |
@@ -94,6 +113,7 @@ runs:
         AWS_DEFAULT_REGION: fsn1
 
     - name: Use cache for Cargo target
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: runs-on/cache@v4
       with:
         path: target/

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -101,7 +101,12 @@ runs:
     - name: Show sccache stats (PR)
       if: github.event_name == 'pull_request'
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Upload binary (PR)
       uses: actions/upload-artifact@v4
@@ -126,7 +131,12 @@ runs:
     - name: Show sccache stats (Release)
       if: github.event_name != 'pull_request'
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
 
     - name: Upload binary (Release)
@@ -153,7 +163,12 @@ runs:
     - name: Show sccache stats after test export (PR)
       if: github.event_name == 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Build and export tests (Release)
       if: github.event_name != 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
@@ -170,7 +185,12 @@ runs:
     - name: Show sccache stats after test export (Release)
       if: github.event_name != 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Upload tests
       uses: actions/upload-artifact@v4

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -78,7 +78,12 @@ runs:
 
     - name: Show sccache stats after integration test
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Run code coverage
       shell: bash
@@ -97,7 +102,12 @@ runs:
 
     - name: Show sccache stats after coverage
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / CI fix

### What was changed?

- Detect whether S3 cache credentials are available in the shared Cargo cache action.
- Skip S3-backed `sccache` and `runs-on/cache` setup when credentials are missing, allowing fork PRs to run CI without private repository secrets.
- Keep the existing S3 cache behavior for trusted branch and repository runs where secrets are available.
- Make `sccache --show-stats` steps tolerate builds where `sccache` was intentionally skipped.

### Related issues

Same contributor CI failure mode as reductstore/reduct-cli#272: public fork PRs do not receive repository secrets, so S3-backed `sccache` can fail before compilation.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed locally:

- `git diff --check`
- YAML parsing for changed workflow/action files
